### PR TITLE
Implement radial menu actions

### DIFF
--- a/src/logic/ar-object-controls.js
+++ b/src/logic/ar-object-controls.js
@@ -25,6 +25,68 @@ const ICONS = [
   'icons/8.png'
 ];
 
+// Utility to get the controlled 3D object
+function getModel() {
+  return document.getElementById(CONTROL_OBJECT_ID);
+}
+
+// ---- 2a. Actions over the AR object ----
+
+function rotateY(delta) {
+  const model = getModel();
+  if (!model) return;
+  const rot = model.getAttribute('rotation');
+  const y = (rot.y || 0) + delta;
+  model.setAttribute('rotation', `${rot.x} ${y} ${rot.z}`);
+}
+
+function scaleModel(factor) {
+  const model = getModel();
+  if (!model) return;
+  const scale = model.getAttribute('scale');
+  const sx = (scale.x || 1) * factor;
+  const sy = (scale.y || 1) * factor;
+  const sz = (scale.z || 1) * factor;
+  model.setAttribute('scale', `${sx} ${sy} ${sz}`);
+}
+
+function toggleModel() {
+  const model = getModel();
+  if (!model) return;
+  const current = parseInt(model.dataset.modelIndex || '0', 10);
+  const next = (current + 1) % 2; // simple toggle between two states
+  if (next === 0) {
+    model.removeAttribute('geometry');
+    model.setAttribute('gltf-model', 'models/000001.glb');
+  } else {
+    model.removeAttribute('gltf-model');
+    model.setAttribute('geometry', 'primitive: box; depth: 1; height: 1; width: 1');
+  }
+  model.dataset.modelIndex = String(next);
+}
+
+function changeColor() {
+  const model = getModel();
+  if (!model) return;
+  const colors = ['red', 'green', 'blue', 'yellow', 'orange', 'purple'];
+  const color = colors[Math.floor(Math.random() * colors.length)];
+  model.setAttribute('material', 'color', color);
+}
+
+function toggleVisibility() {
+  const model = getModel();
+  if (!model) return;
+  const visible = model.getAttribute('visible');
+  model.setAttribute('visible', visible === true || visible === 'true' ? 'false' : 'true');
+}
+
+function resetTransform() {
+  const model = getModel();
+  if (!model) return;
+  model.setAttribute('rotation', '0 0 0');
+  model.setAttribute('scale', '0.5 0.5 0.5');
+}
+
 // ---- 2. Вспомогательные функции ----
 
 function getRadialMenuSVG() {
@@ -113,7 +175,19 @@ function handleMenuClick(e) {
 
   // Пример обработки клика — можно добавить свою логику
   console.log(`Клик по сектору #${sector + 1}`);
-  // TODO: Выполнить действие с 3D-объектом по sector
+  const actions = [
+    () => rotateY(-15),     // sector 1
+    () => rotateY(15),      // sector 2
+    () => scaleModel(1.1),  // sector 3
+    () => scaleModel(0.9),  // sector 4
+    () => toggleModel(),    // sector 5
+    () => changeColor(),    // sector 6
+    () => toggleVisibility(), // sector 7
+    () => resetTransform()  // sector 8
+  ];
+
+  const action = actions[sector];
+  if (action) action();
 }
 
 // ---- 3. Основная функция отрисовки ----


### PR DESCRIPTION
## Summary
- add helpers to modify the 3D model
- implement rotation, scaling, visibility, color and model change actions
- invoke these actions when clicking sectors in the radial menu

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d32b71e3c8320aa1b396d5d486a16