### PR TITLE
Use configured alias imports

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,12 +2,12 @@
   import { onMount } from 'svelte';
 
   // Подключаем стили
-  import './assets/styles.css';
+  import '@assets/styles.css';
 
 
 
   // Логика камеры и трекинга маркера
-  import './logic/camera-ar-core.js';
+  import '@logic/camera-ar-core.js';
   const base = import.meta.env.BASE_URL;
   const markerUrl = `${base}markers_patt/pattern-AGROmarkerWB.patt`;
   const modelUrl = `${base}models/000001.glb`;


### PR DESCRIPTION
## Summary
- switch main styles and logic imports in `App.svelte` to use alias paths

## Testing
- `npm run build` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_b_683d348f13e8832085f406393e3c0817