### PR TITLE
Set base path for GitHub Pages

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -15,7 +15,8 @@ export default defineConfig({
       '@assets': '/src/assets'
     }
   },
-  base: './',
+  // Указываем базовый путь для GitHub Pages
+  base: '/web-app-ar/',
   server: {
     port: 5173,
     open: true,


### PR DESCRIPTION
## Summary
- configure Vite to use `/web-app-ar/` as base path

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run deploy` *(fails: gh-pages not found)*

------
https://chatgpt.com/codex/tasks/task_b_683d3e6fe904832087442c80defdf0b6