### PR TITLE
Fix asset paths and remove invalid dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pnpm install
 pnpm dev
 ```
 
-Открой [http://localhost:5173](http://localhost:5173) в браузере.
+Открой [http://localhost:5173/web-app-ar/](http://localhost:5173/web-app-ar/) в браузере.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 
 <body>
     <div id="ar-frame"></div>
-    <script type="module" src="/src/ar-scene.js"></script>
+    <script type="module" src="./src/ar-scene.js"></script>
 </body>
 
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "mind-ar": "^1.2.5",
         "three": "^0.152.2",
-        "vite": "^5.4.19",
-        "web-app-ar": "file:"
+        "vite": "^5.4.19"
       }
     },
     "node_modules/@babel/runtime": {
@@ -2262,10 +2261,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/web-app-ar": {
-      "resolved": "",
-      "link": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "mind-ar": "^1.2.5",
     "three": "^0.152.2",
-    "vite": "^5.4.19",
-    "web-app-ar": "file:"
+    "vite": "^5.4.19"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       vite:
         specifier: ^5.4.19
         version: 5.4.19(@types/node@22.15.29)
-      web-app-ar:
-        specifier: 'file:'
-        version: file:(@types/node@22.15.29)(seedrandom@3.0.5)
 
 packages:
 
@@ -824,8 +821,6 @@ packages:
       terser:
         optional: true
 
-  'web-app-ar@file:':
-    resolution: {directory: '', type: directory}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -1582,23 +1577,6 @@ snapshots:
       '@types/node': 22.15.29
       fsevents: 2.3.3
 
-  web-app-ar@file:(@types/node@22.15.29)(seedrandom@3.0.5):
-    dependencies:
-      mind-ar: 1.2.5(seedrandom@3.0.5)(three@0.152.2)(vite@5.4.19(@types/node@22.15.29))
-      three: 0.152.2
-      vite: 5.4.19(@types/node@22.15.29)
-    transitivePeerDependencies:
-      - '@types/node'
-      - encoding
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - seedrandom
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
 
   webidl-conversions@3.0.1: {}
 

--- a/src/ar-scene.js
+++ b/src/ar-scene.js
@@ -9,9 +9,10 @@ function setFrameColor(color) {
 }
 
 window.addEventListener('DOMContentLoaded', async () => {
+  const base = import.meta.env.BASE_URL;
   const mindarThree = new MindARThree({
     container: document.body,
-    imageTargetSrc: '/web-app-ar/target.mind',
+    imageTargetSrc: `${base}target.mind`,
   });
 
   const { renderer, scene, camera } = mindarThree;
@@ -21,7 +22,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   const loader = new GLTFLoader();
   let model;
   try {
-    const gltf = await loader.loadAsync('/web-app-ar/assets/model.glb');
+    const gltf = await loader.loadAsync(`${base}assets/model.glb`);
     model = gltf.scene;
   } catch (e) {
     alert('Ошибка загрузки 3D-модели!');


### PR DESCRIPTION
## Summary
- load assets relative to Vite base URL
- fix script path in index
- remove erroneous self-dependency from package.json and locks
- clarify dev server URL in README

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/vite/-/vite-5.4.19.tgz: Forbidden)*
- `pnpm build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842ad33ad688320948c8652fb435aaa