### PR TITLE
Fix AR scene initialization

### DIFF
--- a/src/ar-scene.js
+++ b/src/ar-scene.js
@@ -8,7 +8,9 @@ function setFrameColor(color) {
   if (frame) frame.style.borderColor = color;
 }
 
-window.addEventListener('DOMContentLoaded', async () => {
+// Инициализируем AR-сцену сразу, скрипт подключается в конце body,
+// поэтому событие DOMContentLoaded уже отработало
+const init = async () => {
   const base = import.meta.env.BASE_URL;
   const mindarThree = new MindARThree({
     container: document.body,
@@ -45,4 +47,6 @@ window.addEventListener('DOMContentLoaded', async () => {
 
   await mindarThree.start();
   renderer.setAnimationLoop(() => renderer.render(scene, camera));
-});
+};
+
+init();


### PR DESCRIPTION
## Summary
- initialize AR scene directly because DOMContentLoaded already fired when script loads

## Testing
- `pnpm build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842b52e97108320842a80731cdcdf32