### PR TITLE
Add dedicated AR container

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,15 @@
             overflow: hidden;
         }
 
+        #ar-container {
+            width: 100vw;
+            height: 100vh;
+            position: fixed;
+            top: 0;
+            left: 0;
+            overflow: hidden;
+        }
+
         #ar-frame {
             position: fixed;
             left: 50%;
@@ -47,6 +56,7 @@
 </head>
 
 <body>
+    <div id="ar-container"></div>
     <div id="ar-frame"></div>
     <script type="module" src="./src/ar-scene.js"></script>
 </body>

--- a/src/ar-scene.js
+++ b/src/ar-scene.js
@@ -14,7 +14,7 @@ function setFrameColor(color) {
 const init = async () => {
   const base = import.meta.env.BASE_URL;
   const mindarThree = new MindARThree({
-    container: document.body,
+    container: document.querySelector('#ar-container'),
     imageTargetSrc: `${base}target.mind`,
   });
 


### PR DESCRIPTION
## Summary
- add `<div id="ar-container">` for MindAR output
- make AR container fill the viewport
- initialize `MindARThree` with the new container

## Testing
- `pnpm build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842b7ba28ec832080ecab8fbf3a040d