### PR TITLE
Handle camera init errors

### DIFF
--- a/src/ar-scene.js
+++ b/src/ar-scene.js
@@ -46,7 +46,14 @@ const init = async () => {
     setFrameColor('white');
   };
 
-  await mindarThree.start();
+  try {
+    await mindarThree.start();
+  } catch (e) {
+    alert(
+      'Не удалось инициализировать камеру. Проверьте разрешения и перезагрузите страницу.'
+    );
+    return;
+  }
   renderer.setAnimationLoop(() => renderer.render(scene, camera));
 };
 


### PR DESCRIPTION
## Summary
- wrap `mindarThree.start()` in try/catch
- alert users if camera fails to initialize

## Testing
- `pnpm build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6842b85387a48320af4880842e3ea72e