### PR TITLE
Add ESLint & Prettier configs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "root": true,
+  "env": {
+    "browser": true,
+    "es2022": true,
+    "node": true
+  },
+  "extends": ["eslint:recommended", "plugin:prettier/recommended"],
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {}
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ git clone <repo-url>
 cd <project-name>
 pnpm install
 pnpm dev
+pnpm lint # проверка стиля
+pnpm format # автоформатирование
 ```
 
 Этот проект использует **pnpm** как менеджер пакетов. В репозитории хранится `pnpm-lock.yaml`; файл `package-lock.json` не используется.
@@ -83,6 +85,11 @@ pnpm dev
 - Каждый маркер требует свой `.mind`-файл (генерируй через mindar-cli)
 - Основная логика находится в `src/ar-scene.js`, ассеты загружаются из `public/`
 - Рекомендуемые расширения VS Code: ESLint, Prettier, Vite
+- Для проверки кода и автоформатирования используй:
+  ```bash
+  pnpm lint
+  pnpm format
+  ```
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -5,11 +5,19 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint \"**/*.{js,html}\" --ignore-pattern node_modules/",
+    "format": "prettier --write \"**/*.{js,css,html,json,md}\""
   },
   "dependencies": {
     "mind-ar": "^1.2.5",
     "three": "^0.152.2",
     "vite": "^5.4.19"
+  },
+  "devDependencies": {
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "prettier": "^3.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- add ESLint config
- add Prettier config
- define lint/format scripts in package.json
- document linting & formatting commands in README

## Testing
- `pnpm lint` *(fails: ESLint packages missing)*

------
https://chatgpt.com/codex/tasks/task_b_6842c0419cbc8320a352f8e3be662c3b