### PR TITLE
Add flat ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,27 @@
+import js from '@eslint/js';
+import prettierPlugin from 'eslint-plugin-prettier';
+import configPrettier from 'eslint-config-prettier';
+
+export default [
+  js.configs.recommended,
+  {
+    files: ['**/*.js'],
+    ignores: ['node_modules/**'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+    env: {
+      browser: true,
+      es2022: true,
+      node: true,
+    },
+    plugins: {
+      prettier: prettierPlugin,
+    },
+    rules: {
+      ...configPrettier.rules,
+      'prettier/prettier': 'error',
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint \"**/*.js\" --ignore-pattern node_modules/",
+    "lint": "eslint .",
     "format": "prettier --write \"**/*.{js,css,html,json,md}\""
   },
   "dependencies": {
@@ -18,6 +18,7 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
-    "prettier": "^3.3.1"
+    "prettier": "^3.3.1",
+    "@eslint/js": "^8.57.1"
   }
 }


### PR DESCRIPTION
## Summary
- replace `.eslintrc` with flat config in `eslint.config.js`
- add `@eslint/js` dependency
- simplify lint script for ESLint 9

## Testing
- `pnpm lint` *(fails: Local package.json exists, but node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_b_6842c89a1bec83208ad37a7741e6b949