### PR TITLE
Add start overlay and on-demand AR init

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,14 @@
   <body>
     <div id="ar-container"></div>
     <div id="ar-frame"></div>
-    <script type="module" src="./src/ar-scene.js"></script>
+    <div id="ar-overlay"><button id="start-btn">Start AR</button></div>
+    <script type="module">
+      import { startAR } from './src/ar-scene.js';
+      const overlay = document.getElementById('ar-overlay');
+      document.getElementById('start-btn').addEventListener('click', () => {
+        startAR();
+        overlay.style.display = 'none';
+      });
+    </script>
   </body>
 </html>

--- a/public/mindar-image-three.prod.css
+++ b/public/mindar-image-three.prod.css
@@ -49,3 +49,24 @@
     transform: scaleX(1);
   }
 }
+
+#ar-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 20;
+}
+
+#ar-overlay button {
+  padding: 0.6em 1.2em;
+  font-size: 1.1em;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}

--- a/src/ar-scene.js
+++ b/src/ar-scene.js
@@ -9,9 +9,8 @@ function setFrameColor(color) {
   if (frame) frame.style.borderColor = color;
 }
 
-// Инициализируем AR-сцену сразу, скрипт подключается в конце body,
-// поэтому событие DOMContentLoaded уже отработало
-const init = async () => {
+// Инициализация AR-сцены вызывается по нажатию кнопки
+export const startAR = async () => {
   const base = import.meta.env.BASE_URL;
   const mindarThree = new MindARThree({
     container: document.querySelector('#ar-container'),
@@ -66,5 +65,3 @@ const init = async () => {
   }
   renderer.setAnimationLoop(() => renderer.render(scene, camera));
 };
-
-init();


### PR DESCRIPTION
## Summary
- add overlay button to start AR
- expose `startAR` function in `ar-scene.js`
- hide overlay and start AR on click
- style overlay and button via existing CSS

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_b_68431f6af3948320bd50c3e14b6c3147