### PR TITLE
Fix ESLint alert global comment

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,7 +14,7 @@ export default [
         window: 'readonly',
         document: 'readonly',
         console: 'readonly',
-        alert: 'readonly', // <-- добавь это!
+        alert: 'readonly',
       },
     },
     plugins: {


### PR DESCRIPTION
## Summary
- remove the instructional comment from the `alert` global entry in `eslint.config.js`

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_b_684331047b24832081e3a84d8202df00