### PR TITLE
Add AR frame element and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       }
 
       #ar-frame {
+        display: none;
         position: fixed;
         left: 50%;
         top: 50%;
@@ -56,6 +57,7 @@
 
   <body>
     <div id="ar-container"></div>
+    <div id="ar-frame"></div>
     <div id="ar-overlay"><button id="start-btn">Start AR</button></div>
     <script type="module">
       import { startAR } from './src/ar-scene.js';

--- a/src/ar-scene.js
+++ b/src/ar-scene.js
@@ -9,6 +9,16 @@ function setFrameColor(color) {
   if (frame) frame.style.borderColor = color;
 }
 
+function showFrame() {
+  const frame = document.getElementById('ar-frame');
+  if (frame) frame.style.display = 'block';
+}
+
+function hideFrame() {
+  const frame = document.getElementById('ar-frame');
+  if (frame) frame.style.display = 'none';
+}
+
 // Инициализация AR-сцены вызывается по нажатию кнопки
 export const startAR = async () => {
   const base = import.meta.env.BASE_URL;
@@ -64,13 +74,19 @@ export const startAR = async () => {
 
   anchor.onTargetFound = () => {
     model.visible = true;
+    hideFrame();
+    setFrameColor('green');
   };
   anchor.onTargetLost = () => {
     model.visible = false;
+    showFrame();
+    setFrameColor('white');
   };
 
   try {
     await mindarThree.start();
+    showFrame();
+    setFrameColor('white');
   } catch (e) {
     alert(
       'Не удалось инициализировать камеру. Проверьте разрешения и перезагрузите страницу.',


### PR DESCRIPTION
## Summary
- add AR frame container to the HTML
- implement frame show/hide helper functions
- display/hide frame based on AR session state
- show frame when AR starts and hide it when target found

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68434c4146588320a4fead859beee586