### PR TITLE
Enable orbit controls for model

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,18 @@
           min-height: 90px;
         }
       }
+
+      #instructions {
+        display: none;
+        position: fixed;
+        bottom: 20px;
+        width: 100%;
+        text-align: center;
+        font-family: sans-serif;
+        color: #fff;
+        pointer-events: none;
+        z-index: 20;
+      }
     </style>
   </head>
 
@@ -60,14 +72,22 @@
     <div id="ar-container"></div>
     <div id="ar-frame"></div>
     <div id="ar-overlay"><button id="start-btn">Start AR</button></div>
+    <div id="instructions">Вращайте модель мышью или пальцем, используйте колесо/жест для увеличения.</div>
     <script type="module">
       const overlay = document.getElementById('ar-overlay');
+      const instructions = document.getElementById('instructions');
       document
         .getElementById('start-btn')
         .addEventListener('click', async () => {
           const { startAR } = await import('./src/ar-scene.js');
           const started = await startAR();
-          if (started) overlay.style.display = 'none';
+          if (started) {
+            overlay.style.display = 'none';
+            instructions.style.display = 'block';
+            setTimeout(() => {
+              instructions.style.display = 'none';
+            }, 5000);
+          }
         });
     </script>
   </body>

--- a/src/ar-scene.js
+++ b/src/ar-scene.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { MindARThree } from 'mind-ar/dist/mindar-image-three.prod.js';
 import './styles/mindar-image-three.prod.css';
 import { logEvent } from './utils/analytics.js';
@@ -87,6 +88,11 @@ export const startAR = async () => {
   scene.add(wrapper);
   wrapper.visible = false;
 
+  // Управление камерой
+  const controls = new OrbitControls(camera, renderer.domElement);
+  controls.enablePan = false;
+  controls.enableDamping = true;
+
   // Якорь для маркера
   const anchor = mindarThree.addAnchor(0);
 
@@ -157,6 +163,10 @@ export const startAR = async () => {
     logEvent('sessionError', { message: e?.message });
     return false;
   }
-  renderer.setAnimationLoop(() => renderer.render(scene, camera));
+  renderer.setAnimationLoop(() => {
+    controls.target.copy(wrapper.position);
+    controls.update();
+    renderer.render(scene, camera);
+  });
   return true;
 };


### PR DESCRIPTION
## Summary
- add OrbitControls setup in `ar-scene.js`
- show rotation/zoom hint overlay in `index.html`

## Testing
- `pnpm lint` *(fails: cannot fetch packages)*

------
https://chatgpt.com/codex/tasks/task_b_6843700233008320bbd6b4cc3182ce92