### PR TITLE
Add browser env for ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,6 +10,7 @@ export default [
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
+      env: { browser: true },
       globals: {
         window: 'readonly',
         document: 'readonly',


### PR DESCRIPTION
## Summary
- add `env: { browser: true }` to ESLint config

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/eslint: Forbidden - 403)*
- `pnpm lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_6843758ced4c8320912fbf757d1c472c