### PR TITLE
Update AR controls and auto-start

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,49 +65,54 @@
         pointer-events: none;
         z-index: 20;
       }
+
+      #smooth-controls {
+        display: none;
+        margin-top: 10px;
+        color: white;
+        font-family: sans-serif;
+      }
     </style>
   </head>
 
   <body>
     <div id="ar-container"></div>
     <div id="ar-frame"></div>
-    <div id="ar-overlay">
-      <button id="start-btn">Start AR</button>
-      <div style="margin-top: 10px; color: white; font-family: sans-serif">
-        <label>
-          Position smoothing
-          <input
-            type="range"
-            id="pos-smooth"
-            min="0"
-            max="1"
-            step="0.05"
-            value="0.2"
-          />
-        </label>
-        <label style="margin-left: 10px">
-          Rotation smoothing
-          <input
-            type="range"
-            id="rot-smooth"
-            min="0"
-            max="1"
-            step="0.05"
-            value="0.2"
-          />
-        </label>
-        <label style="margin-left: 10px">
-          Scale smoothing
-          <input
-            type="range"
-            id="scale-smooth"
-            min="0"
-            max="1"
-            step="0.05"
-            value="0.2"
-          />
-        </label>
-      </div>
+    <div id="ar-overlay"></div>
+    <div id="smooth-controls">
+      <label>
+        Position smoothing
+        <input
+          type="range"
+          id="pos-smooth"
+          min="0"
+          max="1"
+          step="0.05"
+          value="0.2"
+        />
+      </label>
+      <label style="margin-left: 10px">
+        Rotation smoothing
+        <input
+          type="range"
+          id="rot-smooth"
+          min="0"
+          max="1"
+          step="0.05"
+          value="0.2"
+        />
+      </label>
+      <label style="margin-left: 10px">
+        Scale smoothing
+        <input
+          type="range"
+          id="scale-smooth"
+          min="0"
+          max="1"
+          step="0.05"
+          value="0.2"
+        />
+      </label>
     </div>
     <div id="instructions">
       Вращайте модель мышью или пальцем, используйте колесо/жест для увеличения.
@@ -115,32 +120,26 @@
     <script type="module">
       const overlay = document.getElementById('ar-overlay');
       const instructions = document.getElementById('instructions');
-      document
-        .getElementById('start-btn')
-        .addEventListener('click', async () => {
-          const { startAR, smoothingParams } = await import(
-            './src/ar-scene.js'
-          );
+      const { startAR, smoothingParams } = await import('./src/ar-scene.js');
 
-          const bind = (id, key) => {
-            const el = document.getElementById(id);
-            el.addEventListener('input', (e) => {
-              smoothingParams[key] = parseFloat(e.target.value);
-            });
-          };
-          bind('pos-smooth', 'positionLerp');
-          bind('rot-smooth', 'rotationLerp');
-          bind('scale-smooth', 'scaleLerp');
-
-          const started = await startAR();
-          if (started) {
-            overlay.style.display = 'none';
-            instructions.style.display = 'block';
-            setTimeout(() => {
-              instructions.style.display = 'none';
-            }, 5000);
-          }
+      const bind = (id, key) => {
+        const el = document.getElementById(id);
+        el.addEventListener('input', (e) => {
+          smoothingParams[key] = parseFloat(e.target.value);
         });
+      };
+      bind('pos-smooth', 'positionLerp');
+      bind('rot-smooth', 'rotationLerp');
+      bind('scale-smooth', 'scaleLerp');
+
+      const started = await startAR();
+      if (started) {
+        overlay.style.display = 'none';
+        instructions.style.display = 'block';
+        setTimeout(() => {
+          instructions.style.display = 'none';
+        }, 5000);
+      }
     </script>
   </body>
 </html>

--- a/src/ar-scene.js
+++ b/src/ar-scene.js
@@ -4,6 +4,7 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 import { MindARThree } from 'mind-ar/dist/mindar-image-three.prod.js';
 import './styles/mindar-image-three.prod.css';
 import { logEvent } from './utils/analytics.js';
+import { showControls, hideControls } from './utils/ui.js';
 
 // Параметры сглаживания движения модели
 export const smoothingParams = {
@@ -28,7 +29,7 @@ function hideFrame() {
   if (frame) frame.style.display = 'none';
 }
 
-// Инициализация AR-сцены вызывается по нажатию кнопки
+// Инициализация AR-сцены при загрузке страницы
 export const startAR = async () => {
   if (!navigator.mediaDevices?.getUserMedia || !window.WebGLRenderingContext) {
     alert('Ваш браузер не поддерживает AR');
@@ -107,12 +108,14 @@ export const startAR = async () => {
 
     wrapper.visible = true;
     hideFrame();
+    showControls();
     setFrameColor('green');
     logEvent('targetFound');
   };
   anchor.onTargetLost = () => {
     wrapper.visible = false;
     showFrame();
+    hideControls();
     setFrameColor('white');
     logEvent('targetLost');
   };

--- a/src/utils/ui.js
+++ b/src/utils/ui.js
@@ -1,0 +1,9 @@
+export function showControls() {
+  const el = document.getElementById('smooth-controls');
+  if (el) el.style.display = 'block';
+}
+
+export function hideControls() {
+  const el = document.getElementById('smooth-controls');
+  if (el) el.style.display = 'none';
+}


### PR DESCRIPTION
## Summary
- auto-start AR scene on page load
- move smoothing sliders to dedicated container
- expose `showControls`/`hideControls` utilities and use them from the AR scene
- display slider controls when a marker is found

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_b_68437750074083208adc13cf430007e5