### PR TITLE
Update pnpm version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
           run_install: false
       - name: Use Node.js 18
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- update pnpm/action-setup to install pnpm v9

## Testing
- `pnpm install --frozen-lockfile` *(fails: lockfile mismatch)*
- `pnpm lint` *(fails: cannot find module `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_b_6843eaff8e1083208a8844a23fcb9ae1