### PR TITLE
Fix duplicate stylesheet load

### DIFF
--- a/src/ar-scene.js
+++ b/src/ar-scene.js
@@ -1,7 +1,6 @@
 import * as THREE from 'three';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { MindARThree } from 'mind-ar/dist/mindar-image-three.prod.js';
-import './styles/mindar-image-three.prod.css';
 import { logEvent } from './utils/analytics.js';
 import { showControls, hideControls } from './utils/ui.js';
 


### PR DESCRIPTION
## Summary
- avoid importing `mindar-image-three.prod.css` in the JS

## Testing
- `pnpm format`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68440833f8688320b3f526e46de493c7