### PR TITLE
Add merge-lockfile helper docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ project-root/
 - **pnpm**: 9.x или новее
 - В репозитории хранится `pnpm-lock.yaml`; `package-lock.json` не используется.
 - В `.gitattributes` указано `pnpm-lock.yaml merge=ours`, локальный lockfile сохраняется при слияниях.
+- При конфликте lockfile установи утилиту `@pnpm/merge-lockfile-changes` командой `pnpm add -D @pnpm/merge-lockfile-changes` и запусти `npx @pnpm/merge-lockfile-changes`.
 - **Современный браузер** (Chrome, Edge, Firefox)
 - Рекомендуется: аккаунт на [GitHub](https://github.com/) для деплоя
 - _(Планируется)_: доступ к MongoDB Atlas или своему серверу MongoDB

--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ pnpm install
 ```
 
 В `.gitattributes` указано `pnpm-lock.yaml merge=ours`, поэтому при слияниях используется локальный lockfile.
-Дополнительно можно применить утилиту [`@pnpm/merge-lockfile-changes`](https://github.com/pnpm/merge-lockfile-changes).
+Установи [`@pnpm/merge-lockfile-changes`](https://github.com/pnpm/merge-lockfile-changes) командой `pnpm add -D @pnpm/merge-lockfile-changes`.
+При конфликте lockfile выполни `npx @pnpm/merge-lockfile-changes` для автоматического слияния.
 
 ### Добавление нового AR-маркера
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.1",
     "globals": "^16.2.0",
-    "prettier": "^3.5.3"
+    "prettier": "^3.5.3",
+    "@pnpm/merge-lockfile-changes": "^2.0.0"
   },
   "engines": {
     "node": ">=18",


### PR DESCRIPTION
## Summary
- document how to run `npx @pnpm/merge-lockfile-changes`
- include install command in README and AGENTS
- add helper as dev dependency

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684420a8f7488320afd11bb81a833f78