### PR TITLE
Unify MongoDB env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment configuration
+MONGODB_URI=mongodb://localhost:27017/ar
+# Optional analytics endpoint
+VITE_ANALYTICS_ENDPOINT=
+# Optional external model URL
+VITE_MODEL_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ package-lock.json
 
 # Local environment variables
 .env
+!/.env.example
 .env.*

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ pnpm format # автоформатирование
 
 Открой [http://localhost:5173/web-app-ar/](http://localhost:5173/web-app-ar/) в браузере и нажми кнопку **Start AR**, чтобы загрузить сцену.
 
-Если планируется отправка аналитики, создай файл `.env` и укажи переменную `VITE_ANALYTICS_ENDPOINT` со ссылкой на свой сервер.
+Если планируется отправка аналитики, скопируй `.env.example` в `.env` и задай переменную `VITE_ANALYTICS_ENDPOINT` со ссылкой на свой сервер.
 Для загрузки моделей из внешнего хранилища можно использовать переменную `VITE_MODEL_URL`.
 
 > **Важно:** приложение должно обслуживаться веб-сервером. Запускай его через `pnpm dev` или статический сервер. Простое открытие `dist/index.html` напрямую в браузере не сработает.
@@ -110,14 +110,14 @@ pnpm format # автоформатирование
 
 ### Настройка MongoDB
 
-1. Задай переменную окружения `MONGO_URL` со строкой подключения к MongoDB.
+1. Скопируй `.env.example` в `.env` и задай переменную `MONGODB_URI` со строкой подключения к MongoDB.
    - Linux/macOS:
      ```bash
-     export MONGO_URL="mongodb://localhost:27017"
+     export MONGODB_URI="mongodb://localhost:27017/ar"
      ```
    - Windows PowerShell:
      ```powershell
-     $env:MONGO_URL="mongodb://localhost:27017"
+     $env:MONGODB_URI="mongodb://localhost:27017/ar"
      ```
 2. Создай базу `ar` и коллекцию `models` через `mongosh`:
    ```bash

--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ import mongoose from 'mongoose';
 const app = express();
 app.use(express.json());
 
-const mongoUrl = process.env.MONGO_URL || 'mongodb://localhost:27017/ar';
+const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/ar';
 
 const modelSchema = new mongoose.Schema({
   name: String,
@@ -13,7 +13,7 @@ const modelSchema = new mongoose.Schema({
 const Model = mongoose.model('Model', modelSchema);
 
 async function main() {
-  await mongoose.connect(mongoUrl);
+  await mongoose.connect(mongoUri);
   // TODO: add Cloudflare R2 synchronization
 
   app.get('/api/models', async (req, res) => {


### PR DESCRIPTION
## Summary
- keep `.env.example` with MONGODB_URI and Vite vars
- exclude `.env.example` from gitignore
- update MongoDB docs to use MONGODB_URI
- adjust server to read MONGODB_URI

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6846bfe31598832093c0a4ace997603b