### PR TITLE
Update multer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "mongoose": "^8.3.0",
     "@aws-sdk/client-s3": "^3.548.0",
     "@aws-sdk/s3-request-presigner": "^3.548.0",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^2.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",


### PR DESCRIPTION
## Summary
- bump multer to 2.0.1

## Testing
- `pnpm install` *(fails: 403 Forbidden)*
- `pnpm lint` *(fails: cannot find @eslint/js because node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_b_6847079c5834832083fdb4da074363bc