### PR TITLE
Fix ESLint globals for server

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,4 +28,12 @@ export default [
       'prettier/prettier': 'error',
     },
   },
+  {
+    files: ['server.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## Summary
- allow Node.js globals for `server.js`

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6847090168b083208c26f57edebd79a6