### PR TITLE
Update download script with HTTP status check

### DIFF
--- a/public/assets/download_models.sh
+++ b/public/assets/download_models.sh
@@ -18,5 +18,12 @@ MODEL_URL="${MODEL_URL:-https://example.com/model.glb}"
 
 echo "Downloading model from $MODEL_URL..."
 mkdir -p "$TARGET_DIR"
-curl -L "$MODEL_URL" -o "$TARGET_DIR/model.glb"
+# Use curl with --fail so the script exits on non-200 responses
+# Capture the HTTP status code to ensure it is 200
+STATUS=$(curl -L --fail -o "$TARGET_DIR/model.glb" -w "%{http_code}" "$MODEL_URL")
+if [ "$STATUS" -ne 200 ]; then
+    echo "Error: failed to download model (HTTP status $STATUS)" >&2
+    rm -f "$TARGET_DIR/model.glb"
+    exit 1
+fi
 echo "Model saved to $TARGET_DIR/model.glb"


### PR DESCRIPTION
## Summary
- ensure `download_models.sh` uses `curl -L --fail`
- exit when the download URL does not return HTTP 200

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_b_68470d7abb0c8320ac017be0e09c99a1