### PR TITLE
Fix .gitignore env duplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ package-lock.json
 .env
 !/.env.example
 .env.*
-.env


### PR DESCRIPTION
## Summary
- remove duplicate `.env` entry from `.gitignore`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68472e0470c48320846a7704044b27e8