### PR TITLE
Fix curl error handling

### DIFF
--- a/public/assets/download_models.sh
+++ b/public/assets/download_models.sh
@@ -18,9 +18,13 @@ MODEL_URL="${MODEL_URL:-https://example.com/model.glb}"
 
 echo "Downloading model from $MODEL_URL..."
 mkdir -p "$TARGET_DIR"
-# Use curl with --fail so the script exits on non-200 responses
-# Capture the HTTP status code to ensure it is 200
-STATUS=$(curl -L --fail -o "$TARGET_DIR/model.glb" -w "%{http_code}" "$MODEL_URL")
+# Download without --fail and handle errors manually
+if ! STATUS=$(curl -L -o "$TARGET_DIR/model.glb" -w "%{http_code}" "$MODEL_URL"); then
+    CURL_EXIT=$?
+    echo "Error: curl failed with code $CURL_EXIT" >&2
+    rm -f "$TARGET_DIR/model.glb"
+    exit 1
+fi
 if [ "$STATUS" -ne 200 ]; then
     echo "Error: failed to download model (HTTP status $STATUS)" >&2
     rm -f "$TARGET_DIR/model.glb"


### PR DESCRIPTION
## Summary
- improve `download_models.sh` so cleanup logic runs when curl fails

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68472fab1da8832081b95fb8b2429caf