### PR TITLE
Add build step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,5 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Lint
         run: pnpm lint
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary
- update CI workflow to run `pnpm build`

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684752c521e4832096a9e806b7f2279a