### PR TITLE
Add Tailwind and Strapi support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ MONGODB_URI=mongodb://localhost:27017/ar
 VITE_ANALYTICS_ENDPOINT=
 # Optional external model URL
 VITE_MODEL_URL=
+# Base URL for Strapi CMS
+VITE_STRAPI_URL=
 # Cloudflare R2 / S3 credentials
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,9 @@
 - [Three.js](https://threejs.org/) — 3D-графика в браузере
 - [MindAR.js (mindar-image)](https://hiukim.github.io/mind-ar-js-doc/) — AR SDK с marker-based трекингом
 - [pnpm](https://pnpm.io/) — менеджер пакетов
+- [Tailwind CSS](https://tailwindcss.com/) — utility‑first CSS
 - [Visual Studio Code](https://code.visualstudio.com/) — основная IDE
+- _(Опционально)_ [Strapi](https://strapi.io/) — headless CMS
 - _(В перспективе)_ [MongoDB](https://www.mongodb.com/) — хранение пользовательских данных и CRM-метаданных
 - _(Планируется)_ [Cloudflare R2](https://www.cloudflare.com/products/r2/) — для хранения `.glb`-моделей
 
@@ -94,6 +96,7 @@ pnpm dev
 
 pnpm build    # production сборка
 pnpm preview  # проверка dist/
+pnpm strapi   # запуск локального Strapi CMS (опционально)
 
 # Открой http://localhost:5173/web-app-ar/ в браузере и нажми кнопку **Start AR** для запуска сцены
 ```
@@ -113,6 +116,7 @@ pnpm preview  # проверка dist/
 6. Для переменных окружения используй `.env` (если потребуются API-ключи).
    - Для отправки аналитики укажи `VITE_ANALYTICS_ENDPOINT=<url>`
    - Для загрузки моделей в R2 задай `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `R2_ENDPOINT` и `R2_BUCKET`
+   - Для доступа к CMS укажи `VITE_STRAPI_URL=http://localhost:1337/api`
 
 ### Как обновить ветку и разрешить конфликт pnpm-lock.yaml
 
@@ -230,6 +234,7 @@ pnpm preview  # проверка dist/
 > Разработка в отдельном агенте/модуле, интеграция по мере готовности.
 
 - **API-интеграция** с [MongoDB Atlas](https://www.mongodb.com/atlas) или своим сервером MongoDB
+- **Strapi CMS** для удобного управления контентом
 - **Логирование** взаимодействия пользователей с маркерами
 - **Привязка данных** (аналитика, контактные формы) к каждому marker target
 - **Хранение .glb** моделей в облаке ([Cloudflare R2](https://www.cloudflare.com/products/r2/))
@@ -244,6 +249,8 @@ pnpm preview  # проверка dist/
 
 - [x] Локальная разработка
 - [x] Совместимость с GitHub Pages
+- [x] Tailwind CSS
+- [ ] Strapi CMS
 - [ ] Интеграция с MongoDB
 - [ ] Аналитика и логи по маркерам
 - [ ] Интеграция с Cloudflare R2
@@ -258,6 +265,8 @@ pnpm preview  # проверка dist/
 - [MindAR Examples](https://github.com/hiukim/mind-ar-js/tree/main/examples)
 - [Three.js Docs](https://threejs.org/docs/index.html#manual/en/introduction/Creating-a-scene)
 - [Vite Docs](https://vitejs.dev/guide/)
+- [Tailwind CSS](https://tailwindcss.com/docs)
+- [Strapi Docs](https://docs.strapi.io/)
 - [MongoDB Atlas](https://www.mongodb.com/atlas)
 - [Cloudflare R2](https://www.cloudflare.com/products/r2/)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@
 - [Three.js](https://threejs.org/) — 3D-графика в браузере
 - [MindAR.js](https://hiukim.github.io/mind-ar-js-doc/) — AR SDK для маркеров
 - [pnpm](https://pnpm.io/) — менеджер пакетов
+- [Tailwind CSS](https://tailwindcss.com/) — utility‑first CSS
 - [MindAR Marker Compiler](https://hiukim.github.io/mind-ar-js-doc/tools/compile/) — онлайн-конвертер PNG/JPG в `.mind`
+- [Strapi](https://strapi.io/) — headless CMS (опционально)
 - ESLint + Prettier (flat config `eslint.config.js`)
 - _(опционально)_ [MongoDB Atlas](https://www.mongodb.com/atlas), [Cloudflare R2](https://www.cloudflare.com/products/r2/)
 
@@ -64,6 +66,7 @@ pnpm format # автоформатирование
 pnpm build # production сборка
 pnpm preview # предпросмотр dist/
 pnpm start  # запуск API-сервера (опционально)
+pnpm strapi # локальный Strapi CMS (опционально)
 ```
 
 Этот проект использует **pnpm** как менеджер пакетов. В репозитории хранится `pnpm-lock.yaml`; файл `package-lock.json` не используется.
@@ -73,6 +76,7 @@ pnpm start  # запуск API-сервера (опционально)
 
 Если планируется отправка аналитики, скопируй `.env.example` в `.env` и задай переменную `VITE_ANALYTICS_ENDPOINT` со ссылкой на свой сервер.
 Для загрузки моделей из внешнего хранилища можно использовать переменную `VITE_MODEL_URL`.
+Для подключения к Strapi укажи `VITE_STRAPI_URL` (например, `http://localhost:1337/api`).
 URL может указывать на объект в Cloudflare R2. Также модель можно передать через параметр `?model=URL` в адресной строке.
 
 Страница [`public/admin.html`](./public/admin.html) по умолчанию обращается к удалённому API `https://web-app-ar-api.onrender.com`. Запускайте собственный сервер (`pnpm api` или `pnpm start`), только если хотите использовать свою базу данных и хранилище. Адрес API можно изменить, отредактировав константу `API_BASE` в `admin.html` (или задать переменную окружения, если добавлена соответствующая поддержка).
@@ -104,7 +108,9 @@ URL может указывать на объект в Cloudflare R2. Также
 # Затем залей содержимое папки dist/ в ветку gh-pages (см. AGENTS.md для подробностей)
 
 # После push может потребоваться удалить отслеживаемые файлы, созданные при deploy, иначе переключение на main может завершиться ошибкой
-# Используй `git clean -fdx` или вернись на основную ветку командой `git checkout -f main` 
+
+# Используй `git clean -fdx` или вернись на основную ветку командой `git checkout -f main`
+
 # (это помогает избежать ошибки "would be overwritten by checkout")
 
 3. Рекомендуется автоматизировать деплой через GitHub Actions.
@@ -220,6 +226,7 @@ pnpm install
 - Интеграция с MongoDB Atlas для хранения статистики и лидов
 - Cloudflare R2 — для хранения `.glb` моделей
 - Аналитика взаимодействия с маркерами
+- Strapi как headless CMS для управления контентом
 
 ---
 
@@ -227,6 +234,8 @@ pnpm install
 
 - [x] Локальная разработка
 - [x] GitHub Pages
+- [x] Tailwind CSS
+- [ ] Strapi CMS
 - [ ] Интеграция с MongoDB
 - [ ] Cloudflare R2
 - [ ] Готовая к продакшену CRM

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AR AgroMarket</title>
+    <link rel="stylesheet" href="./src/style.css" />
     <link rel="stylesheet" href="./src/styles/mindar-image-three.prod.css" />
     <style>
       *,

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{js,css,html,json,md}\"",
     "api": "node server.js",
-    "start": "node server.js"
+    "start": "node server.js",
+    "strapi": "strapi dev"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.548.0",
@@ -32,7 +33,10 @@
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.1",
     "globals": "^16.2.0",
-    "prettier": "^3.5.3"
+    "prettier": "^3.5.3",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.17"
   },
   "engines": {
     "node": ">=18",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/style.css
+++ b/src/style.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/utils/strapi.js
+++ b/src/utils/strapi.js
@@ -1,0 +1,8 @@
+export async function fetchStrapi(contentType, query = '') {
+  const base = import.meta.env.VITE_STRAPI_URL;
+  if (!base) return null;
+  const url = `${base.replace(/\/$/, '')}/${contentType}${query ? `?${query}` : ''}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Strapi request failed: ${res.status}`);
+  return res.json();
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ['./index.html', './src/**/*.{js,html}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- include Tailwind CSS build setup via PostCSS
- add simple Strapi client
- document Tailwind and Strapi usage in README and AGENTS
- expose VITE_STRAPI_URL in env example
- link Tailwind stylesheet in HTML

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_b_6847f7ed28748320bfc5219ce81ff444