### PR TITLE
Add pnpm workspace and update CMS scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ project-root/
 ```bash
 git clone <repo-url>
 cd <project-name>
-pnpm install
+pnpm install       # установит зависимости клиента и CMS
 # скопируй пример конфигурации и заполни значения
 cp .env.example .env
 # при необходимости скачай тяжелые модели
@@ -68,10 +68,10 @@ pnpm format # автоформатирование
 pnpm build # production сборка
 pnpm preview # предпросмотр dist/
 pnpm start  # запуск API-сервера (опционально)
-pnpm strapi # локальный Strapi CMS (опционально)
+pnpm strapi # запускает Strapi CMS (опционально)
 ```
 
-Этот проект использует **pnpm** как менеджер пакетов. В репозитории хранится `pnpm-lock.yaml`; файл `package-lock.json` не используется.
+Этот проект использует **pnpm** как менеджер пакетов. Команда `pnpm install` устанавливает зависимости как для клиента, так и для каталога `strapi`, так как проект настроен как workspace. В репозитории хранится `pnpm-lock.yaml`; файл `package-lock.json` не используется.
 В `.gitattributes` прописано `pnpm-lock.yaml merge=ours`, поэтому при слияниях предпочтение отдаётся локальному lockfile.
 
 Открой [http://localhost:5173/web-app-ar/](http://localhost:5173/web-app-ar/) в браузере и нажми кнопку **Start AR**, чтобы загрузить сцену.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format:check": "prettier --check \"**/*.{js,css,html,json,md}\"",
     "api": "node server.js",
     "start": "node server.js",
-    "strapi": "strapi dev"
+    "strapi": "pnpm --filter strapi dev"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.548.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - '.'
+  - 'strapi'


### PR DESCRIPTION
## Summary
- set up pnpm workspace with root and `strapi`
- run Strapi with `pnpm --filter strapi dev`
- note in docs that `pnpm install` installs all workspace packages and `pnpm strapi` starts the CMS

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Cannot find package '@eslint/js' because registry access is blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6848628536988320b338464543a1e263