### PR TITLE
Update ESLint ignores

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,7 @@ export default [
   js.configs.recommended,
   {
     files: ['**/*.js'],
-    ignores: ['node_modules/**'],
+    ignores: ['node_modules/**', 'strapi/.strapi/**', 'strapi/dist/**'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',


### PR DESCRIPTION
## Summary
- ignore Strapi build folders so ESLint only checks source files

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.826.0.tgz: Forbidden)*
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684867844e648320b8c88acd1071948b