### PR TITLE
Fix VS Code eslint setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": true
   }
 }


### PR DESCRIPTION
## Summary
- enable ESLint auto fixes on save in `.vscode/settings.json`

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm format:check`

------
https://chatgpt.com/codex/tasks/task_b_68486ff68aac8320ab110119b381767f