### PR TITLE
Update lint prerequisites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ pnpm strapi   # запуск локального Strapi CMS (опциональ
    - Для отправки аналитики укажи `VITE_ANALYTICS_ENDPOINT=<url>`
    - Для загрузки моделей в R2 задай `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `R2_ENDPOINT` и `R2_BUCKET`
    - Для доступа к CMS укажи `VITE_STRAPI_URL=http://localhost:1337/api`
+7. Перед запуском `pnpm lint` обязательно установи зависимости командой `pnpm install`.
 
 ### Как обновить ветку и разрешить конфликт pnpm-lock.yaml
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ sh public/assets/download_models.sh
 # пример для Cloudflare R2
 # MODEL_URL=https://<account>.r2.cloudflarestorage.com/<bucket>/model.glb sh public/assets/download_models.sh
 pnpm dev
-pnpm lint # проверка стиля
+pnpm lint # проверка стиля (требует предварительного pnpm install)
 pnpm format # автоформатирование
 pnpm build # production сборка
 pnpm preview # предпросмотр dist/


### PR DESCRIPTION
## Summary
- clarify that `pnpm lint` requires running `pnpm install` first in README quick start
- add same note in AGENTS development instructions

## Testing
- `pnpm lint` *(fails: Cannot find package)*
- `pnpm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6848713bc8788320afe057d782cf7f45