### PR TITLE
Add .eslintignore for Strapi paths

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules/
+strapi/.strapi/
+strapi/dist/
+strapi/**/.strapi/
+strapi/**/dist/


### PR DESCRIPTION
## Summary
- ignore Strapi build outputs in ESLint via `.eslintignore`

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684879ecfbc883209744a8f76468433a