### PR TITLE
Add prettierignore with skip patterns

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules/
+strapi/.strapi/
+strapi/dist/
+strapi/**/.strapi/
+strapi/**/dist/
+dist/


### PR DESCRIPTION
## Summary
- ignore build and dependency folders in Prettier
- verify that formatting skips these paths

## Testing
- `pnpm format`
- `pnpm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68487abe5c148320b239a43b686df52e