### PR TITLE
Move ESLint ignores into config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,0 @@
-node_modules/
-strapi/.strapi/
-strapi/dist/
-strapi/**/.strapi/
-strapi/**/dist/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,10 +5,7 @@ import configPrettier from 'eslint-config-prettier';
 import globals from 'globals';
 
 export default [
-  js.configs.recommended,
-  // Общие правила для JS-файлов фронта (браузер)
   {
-    files: ['**/*.js'],
     ignores: [
       'node_modules/**',
       'strapi/.strapi/**',
@@ -16,6 +13,11 @@ export default [
       'strapi/**/.strapi/**',
       'strapi/**/dist/**',
     ],
+  },
+  js.configs.recommended,
+  // Общие правила для JS-файлов фронта (браузер)
+  {
+    files: ['**/*.js'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',


### PR DESCRIPTION
## Summary
- delete obsolete `.eslintignore`
- move ignore patterns to top-level of `eslint.config.js`

## Testing
- `pnpm install` *(fails: 403 Forbidden)*
- `pnpm lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_b_68488bbae9988320b5ea81d303e8dfa3