### PR TITLE
Fix Strapi PostCSS build error

### DIFF
--- a/strapi/package.json
+++ b/strapi/package.json
@@ -24,12 +24,15 @@
     "react-router-dom": "^6.0.0",
     "styled-components": "^6.0.0"
   },
-  "devDependencies": {
-    "@types/node": "^20",
-    "@types/react": "^18",
-    "@types/react-dom": "^18",
-    "typescript": "^5"
-  },
+    "devDependencies": {
+      "@types/node": "^20",
+      "@types/react": "^18",
+      "@types/react-dom": "^18",
+      "typescript": "^5",
+      "tailwindcss": "^3.4.4",
+      "postcss": "^8.4.38",
+      "autoprefixer": "^10.4.17"
+    },
   "engines": {
     "node": ">=18.0.0 <=22.x.x",
     "npm": ">=6.0.0"


### PR DESCRIPTION
## Summary
- ensure Strapi package has PostCSS dependencies required by the root configuration

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68488dcf93148320958fa4ef468bf639