### PR TITLE
Fix Strapi package.json indentation

### DIFF
--- a/strapi/package.json
+++ b/strapi/package.json
@@ -24,15 +24,15 @@
     "react-router-dom": "^6.0.0",
     "styled-components": "^6.0.0"
   },
-    "devDependencies": {
-      "@types/node": "^20",
-      "@types/react": "^18",
-      "@types/react-dom": "^18",
-      "typescript": "^5",
-      "tailwindcss": "^3.4.4",
-      "postcss": "^8.4.38",
-      "autoprefixer": "^10.4.17"
-    },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
+    "typescript": "^5",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.17"
+  },
   "engines": {
     "node": ">=18.0.0 <=22.x.x",
     "npm": ">=6.0.0"


### PR DESCRIPTION
## Summary
- tidy up `strapi/package.json` formatting so all top-level keys align

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68488f8a18c88320abc674f7a056f101