### PR TITLE
docs: sync guides with repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@
 - [Tailwind CSS](https://tailwindcss.com/) — utility‑first CSS
 - [Visual Studio Code](https://code.visualstudio.com/) — основная IDE
 - _(Опционально)_ [Strapi](https://strapi.io/) — headless CMS
+- [Express](https://expressjs.com/) — API сервер
+- [Vitest](https://vitest.dev/) — тестовый фреймворк
 - _(В перспективе)_ [MongoDB](https://www.mongodb.com/) — хранение пользовательских данных и CRM-метаданных
 - _(Планируется)_ [Cloudflare R2](https://www.cloudflare.com/products/r2/) — для хранения `.glb`-моделей
 
@@ -55,6 +57,9 @@ project-root/
 ├── src/
 │   ├── ar-scene.js        # Инициализация и логика AR
 │   └── utils/             # Вспомогательные функции (по необходимости)
+├── server.js             # API сервер на Express
+├── tests/                # тесты Vitest
+├── strapi/               # директория CMS
 ├── index.html
 ├── vite.config.js
 ├── package.json
@@ -151,6 +156,9 @@ pnpm strapi   # запуск локального Strapi CMS (опциональ
 - `pnpm format` — автоформатирование Prettier.
 - `pnpm build` — production сборка.
 - `pnpm preview` — предпросмотр собранных файлов.
+- `pnpm start` — запуск API-сервера.
+- `pnpm test` — прогон тестов Vitest.
+- `pnpm strapi` — локальный Strapi CMS (опционально).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 - [Tailwind CSS](https://tailwindcss.com/) — utility‑first CSS
 - [MindAR Marker Compiler](https://hiukim.github.io/mind-ar-js-doc/tools/compile/) — онлайн-конвертер PNG/JPG в `.mind`
 - [Strapi](https://strapi.io/) — headless CMS (опционально)
+- [Express](https://expressjs.com/) — API-сервер
+- [Vitest](https://vitest.dev/) — тестовый фреймворк
 - ESLint + Prettier (flat config `eslint.config.js`)
 - _(опционально)_ [MongoDB Atlas](https://www.mongodb.com/atlas), [Cloudflare R2](https://www.cloudflare.com/products/r2/)
 
@@ -43,6 +45,9 @@ project-root/
 ├── src/
 │   ├── ar-scene.js
 │   └── utils/
+├── server.js           # API сервер на Express
+├── tests/              # тесты Vitest
+├── strapi/             # директория CMS
 ├── index.html
 ├── vite.config.js
 └── package.json
@@ -250,6 +255,7 @@ pnpm install
 - [ ] Интеграция с MongoDB
 - [ ] Cloudflare R2
 - [ ] Готовая к продакшену CRM
+- [ ] Аналитика и логи по маркерам
 
 ---
 


### PR DESCRIPTION
## Summary
- mention Express and Vitest in README and AGENTS
- update project structure samples
- note analytics roadmap in README
- document start/test/strapi scripts in AGENTS

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68489255148c83209d76339cb3aea3d9