### PR TITLE
Fix PostCSS config for Vite build

### DIFF
--- a/src/postcss.config.js
+++ b/src/postcss.config.js
@@ -1,6 +1,16 @@
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+import tailwindcss from 'tailwindcss';
+import autoprefixer from 'autoprefixer';
+
+export default (ctx) => {
+  const isStrapi = ctx?.file?.dirname?.includes('strapi');
+  if (isStrapi) {
+    // Strapi admin build doesn't use Tailwind
+    return {
+      plugins: [],
+    };
+  }
+
+  return {
+    plugins: [tailwindcss, autoprefixer],
+  };
 };


### PR DESCRIPTION
## Summary
- return plugin array for Vite
- return empty plugins for Strapi

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684894664f9483208632074b53ec475d