### PR TITLE
Fix Strapi middleware config

### DIFF
--- a/strapi/config/middlewares.ts
+++ b/strapi/config/middlewares.ts
@@ -1,10 +1,14 @@
 export default ({ env }) => [
-  // ...
+  'strapi::errors',
+  'strapi::security',
   {
     name: 'strapi::cors',
     config: {
-      enabled: true,
       origin: env('FRONTEND_ORIGINS', 'http://localhost:5173').split(','),
     },
   },
+  'strapi::query',
+  'strapi::body',
+  'strapi::favicon',
+  'strapi::public',
 ];


### PR DESCRIPTION
## Summary
- add required Strapi middlewares to `middlewares.ts`
- remove deprecated `enabled` flag from `strapi::cors`

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6848990a22a483208156ca391077c4a1