### PR TITLE
Add graceful MongoDB shutdown

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import request from 'supertest';
-import { app, Model } from '../server.js';
+import { app, Model, main } from '../server.js';
+import mongoose from 'mongoose';
 
 process.env.NODE_ENV = 'test';
 
@@ -26,5 +27,16 @@ describe('API endpoints', () => {
     expect(res.body).toEqual({
       error: 'R2_BUCKET environment variable not configured',
     });
+  });
+
+  it('exits process when MongoDB connection fails', async () => {
+    vi.spyOn(mongoose, 'connect').mockRejectedValue(new Error('fail'));
+    const exitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation(() => {
+        /* no-op for tests */
+      });
+    await main();
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
## Summary
- exit if MongoDB connection fails and log helpful errors
- handle SIGINT/SIGTERM to close the mongoose connection
- test that server exits on failed DB connection

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68493083454883208bee79ac0106e586