### PR TITLE
Add Strapi auth integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,10 +79,51 @@
         font-family: sans-serif;
         z-index: 30;
       }
+
+      #menu {
+        position: fixed;
+        top: 10px;
+        right: 10px;
+        z-index: 40;
+        color: white;
+        font-family: sans-serif;
+      }
+
+      #menu form {
+        margin-bottom: 6px;
+      }
+
+      #menu input {
+        margin-right: 4px;
+      }
     </style>
   </head>
 
   <body>
+    <div id="menu">
+      <form id="login-form">
+        <input id="login-identifier" placeholder="Email" required />
+        <input
+          id="login-password"
+          type="password"
+          placeholder="Password"
+          required
+        />
+        <button type="submit">Login</button>
+      </form>
+      <form id="register-form" style="display: none">
+        <input id="register-username" placeholder="Username" required />
+        <input id="register-email" type="email" placeholder="Email" required />
+        <input
+          id="register-password"
+          type="password"
+          placeholder="Password"
+          required
+        />
+        <button type="submit">Register</button>
+      </form>
+      <button id="logout" style="display: none">Logout</button>
+    </div>
     <div id="ar-container"></div>
     <div id="ar-frame"></div>
     <div id="ar-overlay">
@@ -108,8 +149,13 @@
       const startButton = document.getElementById('start-ar');
       const select = document.getElementById('model-select');
       const instructions = document.getElementById('instructions');
+      const loginForm = document.getElementById('login-form');
+      const registerForm = document.getElementById('register-form');
+      const logoutBtn = document.getElementById('logout');
       const { startAR, modelParams } = await import('./src/ar-scene.js');
       const { loadModels } = await import('./src/utils/models.js');
+      const { login, register, logout, isAuthenticated, setToken } =
+        await import('./src/utils/auth.js');
 
       try {
         const list = await loadModels();
@@ -120,6 +166,50 @@
           select.appendChild(opt);
         });
       } catch {}
+
+      function updateMenu() {
+        const logged = isAuthenticated();
+        loginForm.style.display = logged ? 'none' : 'block';
+        registerForm.style.display = logged ? 'none' : 'block';
+        logoutBtn.style.display = logged ? 'block' : 'none';
+        overlay.style.display = logged ? 'block' : 'none';
+      }
+
+      loginForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        try {
+          const { jwt } = await login(
+            document.getElementById('login-identifier').value,
+            document.getElementById('login-password').value,
+          );
+          setToken(jwt);
+          updateMenu();
+        } catch {
+          alert('Login failed');
+        }
+      });
+
+      registerForm.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        try {
+          const { jwt } = await register(
+            document.getElementById('register-username').value,
+            document.getElementById('register-email').value,
+            document.getElementById('register-password').value,
+          );
+          setToken(jwt);
+          updateMenu();
+        } catch {
+          alert('Register failed');
+        }
+      });
+
+      logoutBtn.addEventListener('click', () => {
+        logout();
+        updateMenu();
+      });
+
+      updateMenu();
 
       const bind = (id, key) => {
         const el = document.getElementById(id);

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,40 @@
+export function getToken() {
+  return localStorage.getItem('jwt');
+}
+
+export function setToken(token) {
+  if (token) localStorage.setItem('jwt', token);
+}
+
+export function logout() {
+  localStorage.removeItem('jwt');
+}
+
+export function isAuthenticated() {
+  return Boolean(getToken());
+}
+
+async function sendAuth(path, payload, failMsg) {
+  const base = import.meta.env.VITE_STRAPI_URL;
+  if (!base) throw new Error('VITE_STRAPI_URL not set');
+  const url = `${base.replace(/\/$/, '')}${path}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) throw new Error(`${failMsg}: ${res.status}`);
+  return res.json();
+}
+
+export function login(identifier, password) {
+  return sendAuth('/auth/local', { identifier, password }, 'Login failed');
+}
+
+export function register(username, email, password) {
+  return sendAuth(
+    '/auth/local/register',
+    { username, email, password },
+    'Register failed',
+  );
+}

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  login,
+  register,
+  isAuthenticated,
+  setToken,
+  logout,
+} from '../src/utils/auth.js';
+
+let store;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+  store = {};
+  global.localStorage = {
+    getItem: (k) => store[k] || null,
+    setItem: (k, v) => {
+      store[k] = v;
+    },
+    removeItem: (k) => {
+      delete store[k];
+    },
+  };
+  process.env.VITE_STRAPI_URL = 'http://cms.com/api';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.VITE_STRAPI_URL;
+  delete global.localStorage;
+});
+
+describe('login', () => {
+  it('sends POST to auth/local', async () => {
+    fetch.mockResolvedValue({ ok: true, json: vi.fn() });
+    await login('user', 'pass');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://cms.com/api/auth/local',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ identifier: 'user', password: 'pass' }),
+      }),
+    );
+  });
+
+  it('throws on error status', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 400 });
+    await expect(login('u', 'p')).rejects.toThrow('Login failed: 400');
+  });
+});
+
+describe('register', () => {
+  it('sends POST to auth/local/register', async () => {
+    fetch.mockResolvedValue({ ok: true, json: vi.fn() });
+    await register('u', 'e', 'p');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://cms.com/api/auth/local/register',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: 'u', email: 'e', password: 'p' }),
+      }),
+    );
+  });
+});
+
+describe('auth state', () => {
+  it('tracks token', () => {
+    expect(isAuthenticated()).toBe(false);
+    setToken('t');
+    expect(isAuthenticated()).toBe(true);
+    logout();
+    expect(isAuthenticated()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- integrate simple login/register forms
- add new auth utility
- update index to manage auth state and show AR controls
- test new auth helpers

## Testing
- `pnpm format`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68493bc61dc08320b5b369e757c00c12