### PR TITLE
Update Strapi README for pnpm usage

### DIFF
--- a/strapi/README.md
+++ b/strapi/README.md
@@ -9,9 +9,9 @@ Before starting the server, copy `../.env.example` to `.env` and define `APP_KEY
 Start your Strapi application with autoReload enabled. [Learn more](https://docs.strapi.io/dev-docs/cli#strapi-develop)
 
 ```
-npm run develop
-# or
-yarn develop
+pnpm dev
+# or from the project root
+pnpm strapi
 ```
 
 ### `start`
@@ -19,9 +19,7 @@ yarn develop
 Start your Strapi application with autoReload disabled. [Learn more](https://docs.strapi.io/dev-docs/cli#strapi-start)
 
 ```
-npm run start
-# or
-yarn start
+pnpm start
 ```
 
 ### `build`
@@ -29,9 +27,7 @@ yarn start
 Build your admin panel. [Learn more](https://docs.strapi.io/dev-docs/cli#strapi-build)
 
 ```
-npm run build
-# or
-yarn build
+pnpm build
 ```
 
 ## ⚙️ Deployment
@@ -39,7 +35,7 @@ yarn build
 Strapi gives you many possible deployment options for your project including [Strapi Cloud](https://cloud.strapi.io). Browse the [deployment section of the documentation](https://docs.strapi.io/dev-docs/deployment) to find the best solution for your use case.
 
 ```
-yarn strapi deploy
+pnpm strapi deploy
 ```
 
 ## 📚 Learn more


### PR DESCRIPTION
## Summary
- update `strapi/README.md` to use pnpm commands
- mention `pnpm strapi` root script for development

## Testing
- `pnpm install` *(fails: unable to fetch pnpm)*
- `pnpm lint` *(fails: unable to fetch pnpm)*
- `pnpm test` *(fails: unable to fetch pnpm)*

------
https://chatgpt.com/codex/tasks/task_b_6849973318c8832098dc76af1becbf95