### PR TITLE
Set NODE_ENV for builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,5 @@ jobs:
         run: pnpm format:check
       - name: Build
         run: pnpm build
+        env:
+          NODE_ENV: production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Build project
         run: pnpm build
+        env:
+          NODE_ENV: production
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,8 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+        env:
+          NODE_ENV: production
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist


### PR DESCRIPTION
## Summary
- set `NODE_ENV=production` for pnpm build steps in all workflows

## Testing
- `pnpm lint` *(fails: fetch failed)*
- `pnpm test` *(fails: fetch failed)*
- `pnpm format:check` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_6849bc37c010832099bb6ef4ad8ffc5c