### PR TITLE
Fix formatting in server and utils

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -26,9 +26,18 @@ async function sendAuth(path, payload, failMsg) {
 }
 
 export function login(identifier, password) {
-  return sendAuth('/api/login', { identifier, password }, 'Login failed');
+  // prettier-ignore
+  return sendAuth(
+    '/api/login',
+    { identifier, password },
+    'Login failed',
+  );
 }
 
 export function register(username, email, password) {
-  return sendAuth('/api/register', { username, email, password }, 'Register failed');
+  return sendAuth(
+    '/api/register',
+    { username, email, password },
+    'Register failed',
+  );
 }

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -21,9 +21,7 @@ beforeEach(() => {
       delete store[k];
     },
   };
-  
 });
-
 afterEach(() => {
   vi.restoreAllMocks();
   delete global.localStorage;


### PR DESCRIPTION
## Summary
- format `/upload` route to put middleware on separate lines
- split `sendAuth` calls across multiple lines in auth utils
- tidy `auth.test.js` localStorage mock

## Testing
- `pnpm lint` *(fails: Error when performing the request to registry due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_6849dbb626688320907721519b17a627