### PR TITLE
Add auth route tests and update models tests

### DIFF
--- a/tests/auth.routes.test.js
+++ b/tests/auth.routes.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import request from 'supertest';
+import { app, User } from '../server.js';
+import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
+
+function sign(payload, secret) {
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'HS256', typ: 'JWT' }),
+  ).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${body}`)
+    .digest('base64url');
+  return `${header}.${body}.${signature}`;
+}
+
+describe('auth endpoints', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env.JWT_SECRET = 'secret';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POST /auth/register creates user', async () => {
+    vi.spyOn(User, 'findOne').mockResolvedValue(null);
+    vi.spyOn(bcrypt, 'hash').mockResolvedValue('h');
+    vi.spyOn(User, 'create').mockResolvedValue({ _id: 1 });
+
+    const res = await request(app)
+      .post('/auth/register')
+      .send({ username: 'u', email: 'e', password: 'p' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ jwt: sign({ id: 1 }, 'secret') });
+  });
+
+  it('POST /auth/login returns token', async () => {
+    vi.spyOn(User, 'findOne').mockResolvedValue({ _id: 1, passwordHash: 'h' });
+    vi.spyOn(bcrypt, 'compare').mockResolvedValue(true);
+
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ email: 'e', password: 'p' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ jwt: sign({ id: 1 }, 'secret') });
+  });
+});

--- a/tests/models.test.js
+++ b/tests/models.test.js
@@ -1,29 +1,21 @@
-import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { loadModels } from '../src/utils/models.js';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import request from 'supertest';
+import { app, Model } from '../server.js';
 
-beforeEach(() => {
-  global.fetch = vi.fn();
-});
-
-afterEach(() => {
-  vi.restoreAllMocks();
-  delete global.fetch;
-});
-
-describe('loadModels', () => {
-  it('returns list from API', async () => {
-    const mockJson = vi.fn().mockResolvedValue([{ name: 'm1', url: 'm1.glb' }]);
-    fetch.mockResolvedValue({ ok: true, json: mockJson });
-
-    const models = await loadModels();
-
-    expect(fetch).toHaveBeenCalledWith('/api/models');
-    expect(models).toEqual([{ name: 'm1', url: 'm1.glb' }]);
+describe('GET /api/models', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
-  it('returns empty array on error', async () => {
-    fetch.mockRejectedValue(new Error('fail'));
-    const models = await loadModels();
-    expect(models).toEqual([]);
+  it('returns list of models', async () => {
+    vi.spyOn(Model, 'find').mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      lean: vi.fn().mockResolvedValue([{ name: 'm1', url: 'm1.glb' }]),
+    });
+
+    const res = await request(app).get('/api/models');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ name: 'm1', url: 'm1.glb' }]);
   });
 });
+


### PR DESCRIPTION
## Summary
- update `tests/models.test.js` to hit `/api/models`
- add tests for `/auth/register` and `/auth/login`

## Testing
- `pnpm lint` *(fails: unable to download)*
- `pnpm test` *(fails: unable to download)*

------
https://chatgpt.com/codex/tasks/task_b_6849de22cda083209ac970ba99a85501