### PR TITLE
Simplify postcss setup

### DIFF
--- a/src/postcss.config.js
+++ b/src/postcss.config.js
@@ -1,16 +1,6 @@
 import tailwindcss from 'tailwindcss';
 import autoprefixer from 'autoprefixer';
 
-export default (ctx) => {
-  const isStrapi = ctx?.file?.dirname?.includes('strapi');
-  if (isStrapi) {
-    // Strapi admin build doesn't use Tailwind
-    return {
-      plugins: [],
-    };
-  }
-
-  return {
-    plugins: [tailwindcss, autoprefixer],
-  };
+export default {
+  plugins: [tailwindcss, autoprefixer],
 };


### PR DESCRIPTION
## Summary
- simplify `src/postcss.config.js` to always enable Tailwind CSS and autoprefixer

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/...)*


------
https://chatgpt.com/codex/tasks/task_b_6849de23f0f88320967257e23413b762