### PR TITLE
Fix ESLint config syntax

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,9 +6,8 @@ import globals from 'globals';
 
 export default [
   {
-
     ignores: ['node_modules/**'],
-
+  },
   js.configs.recommended,
   // Общие правила для JS-файлов фронта (браузер)
   {


### PR DESCRIPTION
## Summary
- close the initial object in `eslint.config.js`
- include `js.configs.recommended` as a separate array entry

## Testing
- `pnpm lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_6849e3a710f083208552963a5c87db75