### PR TITLE
Fix duplicated env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # Example environment configuration
+# Connection string for MongoDB
 MONGODB_URI=mongodb://localhost:27017/ar
-# Secret for signing JWT tokens
+
+# Secret key used to sign JWT tokens for API authentication
 JWT_SECRET=
 # Optional analytics endpoint
 VITE_ANALYTICS_ENDPOINT=
@@ -12,10 +14,6 @@ AWS_SECRET_ACCESS_KEY=
 AWS_REGION=
 R2_ENDPOINT=
 R2_BUCKET=
-
-# Secret key for JWT authentication
-JWT_SECRET=
-
 
 # Port for API server (default 3000; Render.com uses 10000)
 PORT=3000


### PR DESCRIPTION
## Summary
- remove extra `JWT_SECRET` entry from `.env.example`
- add clearer description of the env var

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_6849e4c59ee483208c8e64356e89696a