### PR TITLE
Surface auth server errors

### DIFF
--- a/cp.html
+++ b/cp.html
@@ -166,8 +166,8 @@
             setToken(jwt);
             updateUI();
             await refreshModels();
-          } catch {
-            alert('Login failed');
+          } catch (err) {
+            alert(err.message);
           }
         });
 
@@ -184,8 +184,8 @@
             setToken(jwt);
             updateUI();
             await refreshModels();
-          } catch {
-            alert('Register failed');
+          } catch (err) {
+            alert(err.message);
           }
         });
 

--- a/index.html
+++ b/index.html
@@ -184,8 +184,8 @@
           );
           setToken(jwt);
           updateMenu();
-        } catch {
-          alert('Login failed');
+        } catch (err) {
+          alert(err.message);
         }
       });
 
@@ -199,8 +199,8 @@
           );
           setToken(jwt);
           updateMenu();
-        } catch {
-          alert('Register failed');
+        } catch (err) {
+          alert(err.message);
         }
       });
 

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -21,8 +21,11 @@ async function sendAuth(path, payload, failMsg) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
   });
-  if (!res.ok) throw new Error(`${failMsg}: ${res.status}`);
-  return res.json();
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(data.error || `${failMsg}: ${res.status}`);
+  }
+  return data;
 }
 
 export function login(email, password) {

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -41,9 +41,13 @@ describe('login', () => {
     );
   });
 
-  it('throws on error status', async () => {
-    fetch.mockResolvedValue({ ok: false, status: 400 });
-    await expect(login('e', 'p')).rejects.toThrow('Login failed: 400');
+  it('throws server error text', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: vi.fn().mockResolvedValue({ error: 'Invalid credentials' }),
+    });
+    await expect(login('e', 'p')).rejects.toThrow('Invalid credentials');
   });
 });
 
@@ -59,6 +63,15 @@ describe('register', () => {
         body: JSON.stringify({ username: 'u', email: 'e', password: 'p' }),
       }),
     );
+  });
+
+  it('throws server error text', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: vi.fn().mockResolvedValue({ error: 'Email exists' }),
+    });
+    await expect(register('u', 'e', 'p')).rejects.toThrow('Email exists');
   });
 });
 


### PR DESCRIPTION
## Summary
- forward error text from API in `sendAuth`
- display received error messages in index and cp pages
- extend unit tests to verify error propagation

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*
- `pnpm format` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_6849e7a1c6ac8320abf1bb47d5999fbb