### PR TITLE
Fix auth tests mock return

### DIFF
--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -29,7 +29,7 @@ afterEach(() => {
 
 describe('login', () => {
   it('sends POST to /auth/login', async () => {
-    fetch.mockResolvedValue({ ok: true, json: vi.fn() });
+    fetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({}) });
     await login('user@example.com', 'pass');
     expect(fetch).toHaveBeenCalledWith(
       '/auth/login',
@@ -53,7 +53,7 @@ describe('login', () => {
 
 describe('register', () => {
   it('sends POST to /auth/register', async () => {
-    fetch.mockResolvedValue({ ok: true, json: vi.fn() });
+    fetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({}) });
     await register('u', 'e', 'p');
     expect(fetch).toHaveBeenCalledWith(
       '/auth/register',


### PR DESCRIPTION
## Summary
- update resolved values in `auth.test.js`

## Testing
- `pnpm format` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*
- `NODE_ENV=test pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_6849e9725bf483208e82590fc64fc7cd