### PR TITLE
Add API base URL support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ JWT_SECRET=
 VITE_ANALYTICS_ENDPOINT=
 # Optional external model URL
 VITE_MODEL_URL=
+# Base URL for API requests when building the frontend
+VITE_API_BASE_URL=
 # Cloudflare R2 / S3 credentials
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ pnpm start  # запуск API-сервера (опционально)
    > ⚠️ Значение `base` должно совпадать с названием репозитория на GitHub.
    > Обязательно укажите `build.target = 'esnext'`, иначе топ-левел `await` не
    > будет работать на GitHub Pages.
-2. Сборка и деплой:
+2. Укажи URL бэкенда через `VITE_API_BASE_URL`, чтобы `cp.html` мог обращаться к API:
    ```bash
-   pnpm build
+   VITE_API_BASE_URL=https://example.com pnpm build
    ```
 
 # Затем залей содержимое папки dist/ в ветку gh-pages (см. AGENTS.md для подробностей)

--- a/cp.html
+++ b/cp.html
@@ -59,6 +59,11 @@
       <h1 style="margin-top: 0; margin-bottom: 1rem; font-size: 1.25rem">
         Upload 3D Models
       </h1>
+      <p
+        id="api-warning"
+        class="hidden"
+        style="color: red; margin-bottom: 0.5rem"
+      ></p>
       <div id="auth" style="margin-bottom: 1rem">
         <form id="login-form" class="inline-form">
           <input
@@ -127,17 +132,32 @@
       } from './src/utils/auth.js';
       import { loadModels } from './src/utils/models.js';
 
+      const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+
+      function showWarning(msg) {
+        const el = document.getElementById('api-warning');
+        el.textContent = msg;
+        el.classList.remove('hidden');
+      }
+
+      function clearWarning() {
+        document.getElementById('api-warning').classList.add('hidden');
+      }
+
       async function refreshModels() {
         const list = document.getElementById('model-list');
         list.innerHTML = '';
         try {
           const models = await loadModels();
+          clearWarning();
           models.forEach((m) => {
             const li = document.createElement('li');
             li.textContent = `${m.name} (${m.url})`;
             list.appendChild(li);
           });
-        } catch {}
+        } catch {
+          showWarning('Failed to load models');
+        }
       }
 
       function updateUI() {
@@ -166,8 +186,9 @@
             setToken(jwt);
             updateUI();
             await refreshModels();
+            clearWarning();
           } catch (err) {
-            alert(err.message);
+            showWarning(err.message);
           }
         });
 
@@ -184,8 +205,9 @@
             setToken(jwt);
             updateUI();
             await refreshModels();
+            clearWarning();
           } catch (err) {
-            alert(err.message);
+            showWarning(err.message);
           }
         });
 
@@ -193,6 +215,7 @@
         logout();
         updateUI();
         document.getElementById('model-list').innerHTML = '';
+        clearWarning();
       });
 
       document
@@ -203,7 +226,7 @@
           const form = new FormData();
           if (fileInput.files[0]) form.append('model', fileInput.files[0]);
           try {
-            const res = await fetch('/upload', {
+            const res = await fetch(`${API_BASE}/upload`, {
               method: 'POST',
               headers: {
                 Authorization: `Bearer ${localStorage.getItem('jwt')}`,
@@ -214,7 +237,7 @@
             fileInput.value = '';
             await refreshModels();
           } catch {
-            alert('Upload failed');
+            showWarning('Upload failed');
           }
         });
 

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -14,8 +14,10 @@ export function isAuthenticated() {
   return Boolean(getToken());
 }
 
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+
 async function sendAuth(path, payload, failMsg) {
-  const url = path;
+  const url = API_BASE + path;
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },

--- a/src/utils/models.js
+++ b/src/utils/models.js
@@ -1,6 +1,8 @@
+const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+
 export async function loadModels() {
   try {
-    const res = await fetch('/api/models');
+    const res = await fetch(`${API_BASE}/api/models`);
     if (!res.ok) throw new Error(`API request failed: ${res.status}`);
     return await res.json();
   } catch (e) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,16 +1,24 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import postcss from './src/postcss.config.js';
 
-export default defineConfig({
-  base: '/web-app-ar/',
-  build: {
-    target: 'esnext',
-    rollupOptions: {
-      input: {
-        main: 'index.html',
-        cp: 'cp.html',
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  return {
+    base: '/web-app-ar/',
+    build: {
+      target: 'esnext',
+      rollupOptions: {
+        input: {
+          main: 'index.html',
+          cp: 'cp.html',
+        },
       },
     },
-  },
-  css: { postcss },
+    css: { postcss },
+    define: {
+      'import.meta.env.VITE_API_BASE_URL': JSON.stringify(
+        env.VITE_API_BASE_URL,
+      ),
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- allow configuring API URL via `VITE_API_BASE_URL`
- prefix all auth and model requests with that base URL
- warn in cp.html when API requests fail
- document `VITE_API_BASE_URL` usage for GitHub Pages

## Testing
- `npx prettier -w "**/*.{js,css,html,json,md}"`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*
- `pnpm format` *(fails: unable to download pnpm)*
- `pnpm test` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_b_6849ec5a9afc8320aeb45a4840beb1c1