### PR TITLE
Improve login page

### DIFF
--- a/cp.html
+++ b/cp.html
@@ -80,8 +80,9 @@
             required
           />
           <button class="button button-primary" type="submit">Login</button>
+          <button class="button" type="button" id="show-register">Register</button>
         </form>
-        <form id="register-form" class="inline-form">
+        <form id="register-form" class="inline-form" style="display: none">
           <input
             id="reg-username"
             class="text-input"
@@ -103,6 +104,7 @@
             required
           />
           <button class="button button-primary" type="submit">Register</button>
+          <button class="button" type="button" id="show-login">Back</button>
         </form>
         <button id="logout" class="button button-secondary hidden">
           Logout
@@ -166,14 +168,22 @@
         }
       }
 
+      let showRegister = false;
+
       function updateUI() {
         const logged = isAuthenticated();
-        document.getElementById('login-form').style.display = logged
-          ? 'none'
-          : 'flex';
-        document.getElementById('register-form').style.display = logged
-          ? 'none'
-          : 'flex';
+        const loginFormEl = document.getElementById('login-form');
+        const regFormEl = document.getElementById('register-form');
+        if (logged) {
+          loginFormEl.style.display = 'none';
+          regFormEl.style.display = 'none';
+        } else if (showRegister) {
+          loginFormEl.style.display = 'none';
+          regFormEl.style.display = 'flex';
+        } else {
+          loginFormEl.style.display = 'flex';
+          regFormEl.style.display = 'none';
+        }
         document.getElementById('logout').classList.toggle('hidden', !logged);
         document
           .getElementById('upload-form')
@@ -224,6 +234,18 @@
             showWarning(err.message);
           }
         });
+
+      document
+        .getElementById('show-register')
+        .addEventListener('click', () => {
+          showRegister = true;
+          updateUI();
+        });
+
+      document.getElementById('show-login').addEventListener('click', () => {
+        showRegister = false;
+        updateUI();
+      });
 
       document.getElementById('logout').addEventListener('click', () => {
         logout();

--- a/index.html
+++ b/index.html
@@ -110,6 +110,7 @@
           required
         />
         <button type="submit">Login</button>
+        <button type="button" id="show-register">Register</button>
       </form>
       <form id="register-form" style="display: none">
         <input id="register-username" placeholder="Username" required />
@@ -121,6 +122,7 @@
           required
         />
         <button type="submit">Register</button>
+        <button type="button" id="show-login">Back</button>
       </form>
       <button id="logout" style="display: none">Logout</button>
     </div>
@@ -185,10 +187,20 @@
         markerSelect.addEventListener('change', (e) => populate(e.target.value));
       } catch {}
 
+      let showRegister = false;
+
       function updateMenu() {
         const logged = isAuthenticated();
-        loginForm.style.display = logged ? 'none' : 'block';
-        registerForm.style.display = logged ? 'none' : 'block';
+        if (logged) {
+          loginForm.style.display = 'none';
+          registerForm.style.display = 'none';
+        } else if (showRegister) {
+          loginForm.style.display = 'none';
+          registerForm.style.display = 'block';
+        } else {
+          loginForm.style.display = 'block';
+          registerForm.style.display = 'none';
+        }
         logoutBtn.style.display = logged ? 'block' : 'none';
         overlay.style.display = logged ? 'block' : 'none';
       }
@@ -224,6 +236,18 @@
 
       logoutBtn.addEventListener('click', () => {
         logout();
+        updateMenu();
+      });
+
+      document
+        .getElementById('show-register')
+        .addEventListener('click', () => {
+          showRegister = true;
+          updateMenu();
+        });
+
+      document.getElementById('show-login').addEventListener('click', () => {
+        showRegister = false;
         updateMenu();
       });
 


### PR DESCRIPTION
## Summary
- toggle registration form instead of showing both
- update content manager login page accordingly

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_6849ee8b31d88320b71a8dcc65b88181