### PR TITLE
Resolve linter warnings in tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,7 +33,7 @@ export default [
   },
   // Node.js/Backend
   {
-    files: ['server.js'],
+    files: ['server.js', 'vite.config.js', 'vitest.config.js'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',

--- a/tests/models.test.js
+++ b/tests/models.test.js
@@ -10,9 +10,9 @@ describe('GET /api/models', () => {
   it('returns list of models', async () => {
     vi.spyOn(Model, 'find').mockReturnValue({
       select: vi.fn().mockReturnThis(),
-      lean: vi.fn().mockResolvedValue([
-        { name: 'm1', url: 'm1.glb', markerIndex: 0 },
-      ]),
+      lean: vi
+        .fn()
+        .mockResolvedValue([{ name: 'm1', url: 'm1.glb', markerIndex: 0 }]),
     });
 
     const res = await request(app).get('/api/models');

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -15,9 +15,9 @@ describe('API endpoints', () => {
   it('GET /api/models returns data', async () => {
     vi.spyOn(Model, 'find').mockReturnValue({
       select: vi.fn().mockReturnThis(),
-      lean: vi.fn().mockResolvedValue([
-        { name: 'foo', url: 'a.glb', markerIndex: 0 },
-      ]),
+      lean: vi
+        .fn()
+        .mockResolvedValue([{ name: 'foo', url: 'a.glb', markerIndex: 0 }]),
     });
     const res = await request(app).get('/api/models');
     expect(res.status).toBe(200);
@@ -79,9 +79,7 @@ describe('API endpoints', () => {
     process.env.R2_BUCKET = 'b';
     process.env.JWT_SECRET = 's';
     vi.spyOn(S3Client.prototype, 'send').mockResolvedValue({});
-    const updateSpy = vi
-      .spyOn(Model, 'updateOne')
-      .mockResolvedValue({});
+    const updateSpy = vi.spyOn(Model, 'updateOne').mockResolvedValue({});
     const token = sign({ id: 1 }, 's');
     const res = await request(app)
       .post('/upload')


### PR DESCRIPTION
## Summary
- clean up Prettier formatting in model and server tests
- allow Node globals for vite config in ESLint setup

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/...)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_b_6849efb24c2c8320acd8d5850662dad3