### PR TITLE
Fix JWT_SECRET usage in unauthorized upload test

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -56,6 +56,7 @@ describe('API endpoints', () => {
 
   it('POST /upload rejects unauthorized', async () => {
     process.env.R2_BUCKET = 'b';
+    process.env.JWT_SECRET = 'dummy';
     const res = await request(app)
       .post('/upload')
       .attach('model', Buffer.from('data'), 'm.glb');


### PR DESCRIPTION
## Summary
- ensure unauthorized upload test initializes `JWT_SECRET`

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/...)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_b_6849f2832e908320bd4e50bae3ccb029