### PR TITLE
Fix conditional auth header in cp upload

### DIFF
--- a/cp.html
+++ b/cp.html
@@ -262,11 +262,12 @@
           const form = new FormData();
           if (fileInput.files[0]) form.append('model', fileInput.files[0]);
           try {
+            const headers = {};
+            const token = localStorage.getItem('jwt');
+            if (token) headers.Authorization = `Bearer ${token}`;
             const res = await fetch(`${API_BASE}/upload`, {
               method: 'POST',
-              headers: {
-                Authorization: `Bearer ${localStorage.getItem('jwt')}`,
-              },
+              headers,
               body: form,
             });
             if (!res.ok) throw new Error('upload failed');


### PR DESCRIPTION
## Summary
- add conditional logic for Authorization header when uploading models

## Testing
- `pnpm lint` *(fails: Error when performing the request to registry.npmjs.org)*
- `pnpm test` *(fails: Error when performing the request to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_6849f360282083208c5466117ce2fd14