### PR TITLE
Fix env restoration in tests

### DIFF
--- a/tests/auth.routes.test.js
+++ b/tests/auth.routes.test.js
@@ -17,13 +17,20 @@ function sign(payload, secret) {
 }
 
 describe('auth endpoints', () => {
+  let originalR2;
+  let originalSecret;
+
   beforeEach(() => {
     vi.restoreAllMocks();
+    originalR2 = process.env.R2_BUCKET;
+    originalSecret = process.env.JWT_SECRET;
     process.env.JWT_SECRET = 'secret';
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    process.env.R2_BUCKET = originalR2;
+    process.env.JWT_SECRET = originalSecret;
   });
 
   it('POST /auth/register creates user', async () => {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { app, Model, main } from '../server.js';
 import mongoose from 'mongoose';
@@ -8,8 +8,19 @@ import { S3Client } from '@aws-sdk/client-s3';
 process.env.NODE_ENV = 'test';
 
 describe('API endpoints', () => {
+  let originalR2;
+  let originalSecret;
+
   beforeEach(() => {
     vi.restoreAllMocks();
+    originalR2 = process.env.R2_BUCKET;
+    originalSecret = process.env.JWT_SECRET;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    process.env.R2_BUCKET = originalR2;
+    process.env.JWT_SECRET = originalSecret;
   });
 
   it('GET /api/models returns data', async () => {


### PR DESCRIPTION
## Summary
- capture original R2_BUCKET and JWT_SECRET in each test suite
- restore these env variables after each test

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_6849f524cad0832094f25e9dcd8e5d99