### PR TITLE
Fix JWT secret setup in upload rejection test

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -56,7 +56,8 @@ describe('API endpoints', () => {
 
   it('POST /upload rejects unauthorized', async () => {
     process.env.R2_BUCKET = 'b';
-    process.env.JWT_SECRET = 'dummy';
+    // set secret so auth middleware doesn't return 500
+    process.env.JWT_SECRET = 'dummy-secret';
     const res = await request(app)
       .post('/upload')
       .attach('model', Buffer.from('data'), 'm.glb');


### PR DESCRIPTION
## Summary
- ensure `/upload` unauthorized test sets `JWT_SECRET` before calling request

## Testing
- `pnpm test` *(fails: fetch to npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6849f526e8288320973b72269594d0cb