### PR TITLE
Add default AWS region

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ pnpm start
 - `GET /model/:filename` — выдаёт временную ссылку на модель
 - `POST /auth/register` — регистрация пользователя
 - `POST /auth/login` — получение JWT
-- перед запуском задайте переменные `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `R2_ENDPOINT`, `R2_BUCKET` и `JWT_SECRET`
+- перед запуском задайте переменные `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` (по умолчанию `us-east-1`), `R2_ENDPOINT`, `R2_BUCKET` и `JWT_SECRET`
 
 > `JWT_SECRET` является обязательной переменной. Если она не указана, защищённые маршруты API вернут код `500`. Задайте `JWT_MISSING_STATUS`, чтобы изменить этот код.
 

--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ const s3 = new S3Client({
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
   },
   endpoint: process.env.R2_ENDPOINT,
-  region: process.env.AWS_REGION,
+  region: process.env.AWS_REGION || 'us-east-1',
 });
 
 const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/ar';


### PR DESCRIPTION
## Summary
- default to `us-east-1` region when creating `S3Client`
- document the default region in API setup docs

## Testing
- `pnpm test` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_b_684a962c1aac83208ae23437b6dc7812