### PR TITLE
Fix lean stub formatting

### DIFF
--- a/tests/models.test.js
+++ b/tests/models.test.js
@@ -31,9 +31,9 @@ describe('model routes', () => {
   it('GET /api/models returns list', async () => {
     vi.spyOn(Model, 'find').mockReturnValue({
       select: vi.fn().mockReturnThis(),
-      lean: vi.fn().mockResolvedValue([
-        { name: 'm1', url: 'm1.glb', markerIndex: 0 },
-      ]),
+      lean: vi
+        .fn()
+        .mockResolvedValue([{ name: 'm1', url: 'm1.glb', markerIndex: 0 }]),
     });
 
     const res = await request(app).get('/api/models');


### PR DESCRIPTION
## Summary
- fix stub formatting for `lean` in tests/models.test.js

## Testing
- `pnpm install` *(fails: fetch failed)*
- `pnpm lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_684aee195eb883208a2bba5462698925