### PR TITLE
Fix model CRUD spies with lean

### DIFF
--- a/tests/models.test.js
+++ b/tests/models.test.js
@@ -42,10 +42,12 @@ describe('model routes', () => {
   });
 
   it('GET /api/models/:id returns single model', async () => {
-    vi.spyOn(Model, 'findById').mockResolvedValue({
-      name: 'm',
-      url: 'm.glb',
-      markerIndex: 1,
+    vi.spyOn(Model, 'findById').mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        name: 'm',
+        url: 'm.glb',
+        markerIndex: 1,
+      }),
     });
 
     const res = await request(app).get('/api/models/123');
@@ -56,9 +58,13 @@ describe('model routes', () => {
   it('PUT /api/models/:id updates model', async () => {
     process.env.JWT_SECRET = 's';
     const token = sign({ id: 1 }, 's');
-    const spy = vi
-      .spyOn(Model, 'findByIdAndUpdate')
-      .mockResolvedValue({ name: 'x', url: 'x.glb', markerIndex: 2 });
+    const spy = vi.spyOn(Model, 'findByIdAndUpdate').mockReturnValue({
+      lean: vi.fn().mockResolvedValue({
+        name: 'x',
+        url: 'x.glb',
+        markerIndex: 2,
+      }),
+    });
 
     const res = await request(app)
       .put('/api/models/123')
@@ -76,7 +82,9 @@ describe('model routes', () => {
   it('DELETE /api/models/:id removes model', async () => {
     process.env.JWT_SECRET = 's';
     const token = sign({ id: 1 }, 's');
-    const spy = vi.spyOn(Model, 'findByIdAndDelete').mockResolvedValue({});
+    const spy = vi.spyOn(Model, 'findByIdAndDelete').mockReturnValue({
+      lean: vi.fn().mockResolvedValue({}),
+    });
 
     const res = await request(app)
       .delete('/api/models/123')


### PR DESCRIPTION
## Summary
- mock chained `lean()` for model CRUD tests

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*
- `pnpm format` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_684af07e073083208efa969093a3ea3f