### PR TITLE
Fix invalid filename test

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -127,7 +127,7 @@ describe('API endpoints', () => {
     const res = await request(app)
       .post('/upload')
       .set('Authorization', `Bearer ${token}`)
-      .attach('model', Buffer.from('data'), '../evil.glb');
+      .attach('model', Buffer.from('data'), { filename: '../evil.glb' });
     expect(res.status).toBe(400);
     expect(res.body).toEqual({ error: 'Invalid filename' });
   });


### PR DESCRIPTION
## Summary
- use options object for evil filename upload test

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_684af2154dc483208b14e87b0e78ac5f