### PR TITLE
Add auth failure tests

### DIFF
--- a/tests/models.test.js
+++ b/tests/models.test.js
@@ -67,6 +67,20 @@ describe('model routes', () => {
     );
   });
 
+  it('PUT /api/models/:id without Authorization returns 401', async () => {
+    process.env.JWT_SECRET = 's';
+    const spy = vi
+      .spyOn(Model, 'findByIdAndUpdate')
+      .mockReturnValue({ lean: vi.fn() });
+
+    const res = await request(app)
+      .put('/api/models/123')
+      .send({ name: 'x', url: 'x.glb', markerIndex: 2 });
+
+    expect(res.status).toBe(401);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   it('DELETE /api/models/:id removes model', async () => {
     process.env.JWT_SECRET = 's';
     const token = sign({ id: 1 }, 's');
@@ -81,5 +95,17 @@ describe('model routes', () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ success: true });
     expect(spy).toHaveBeenCalledWith('123');
+  });
+
+  it('DELETE /api/models/:id without Authorization returns 401', async () => {
+    process.env.JWT_SECRET = 's';
+    const spy = vi
+      .spyOn(Model, 'findByIdAndDelete')
+      .mockReturnValue({ lean: vi.fn() });
+
+    const res = await request(app).delete('/api/models/123');
+
+    expect(res.status).toBe(401);
+    expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add tests for missing `Authorization` header for update and delete model routes

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_684af5a7bf4c8320b594f39b45ce067b