### PR TITLE
Deduplicate JWT sign helper

### DIFF
--- a/tests/auth.routes.test.js
+++ b/tests/auth.routes.test.js
@@ -2,19 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import { app, User } from '../server.js';
 import bcrypt from 'bcryptjs';
-import crypto from 'crypto';
+import { sign } from './helpers/sign.js';
 
-function sign(payload, secret) {
-  const header = Buffer.from(
-    JSON.stringify({ alg: 'HS256', typ: 'JWT' }),
-  ).toString('base64url');
-  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
-  const signature = crypto
-    .createHmac('sha256', secret)
-    .update(`${header}.${body}`)
-    .digest('base64url');
-  return `${header}.${body}.${signature}`;
-}
 
 describe('auth endpoints', () => {
   let originalR2;

--- a/tests/helpers/sign.js
+++ b/tests/helpers/sign.js
@@ -1,0 +1,13 @@
+import crypto from 'crypto';
+
+export function sign(payload, secret) {
+  const header = Buffer.from(
+    JSON.stringify({ alg: 'HS256', typ: 'JWT' }),
+  ).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  const signature = crypto
+    .createHmac('sha256', secret)
+    .update(`${header}.${body}`)
+    .digest('base64url');
+  return `${header}.${body}.${signature}`;
+}

--- a/tests/models.test.js
+++ b/tests/models.test.js
@@ -1,19 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { app, Model } from '../server.js';
-import crypto from 'crypto';
-
-function sign(payload, secret) {
-  const header = Buffer.from(
-    JSON.stringify({ alg: 'HS256', typ: 'JWT' }),
-  ).toString('base64url');
-  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
-  const signature = crypto
-    .createHmac('sha256', secret)
-    .update(`${header}.${body}`)
-    .digest('base64url');
-  return `${header}.${body}.${signature}`;
-}
+import { sign } from './helpers/sign.js';
 
 describe('model routes', () => {
   let originalSecret;

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { app, Model, main } from '../server.js';
 import mongoose from 'mongoose';
-import crypto from 'crypto';
 import { S3Client } from '@aws-sdk/client-s3';
+import { sign } from './helpers/sign.js';
 
 process.env.NODE_ENV = 'test';
 
@@ -53,17 +53,6 @@ describe('API endpoints', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  function sign(payload, secret) {
-    const header = Buffer.from(
-      JSON.stringify({ alg: 'HS256', typ: 'JWT' }),
-    ).toString('base64url');
-    const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
-    const signature = crypto
-      .createHmac('sha256', secret)
-      .update(`${header}.${body}`)
-      .digest('base64url');
-    return `${header}.${body}.${signature}`;
-  }
 
   it('POST /upload rejects unauthorized', async () => {
     process.env.R2_BUCKET = 'b';


### PR DESCRIPTION
## Summary
- centralize JWT signing in a new helper under `tests/helpers/sign.js`
- import the helper in test suites instead of repeating the function

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/... )*


------
https://chatgpt.com/codex/tasks/task_b_684af3f3f1a88320be9abfd1c87d69f7