### PR TITLE
Update Node engines range

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "supertest": "^6.3.3"
   },
   "engines": {
-    "node": ">=18",
+    "node": ">=18 <22",
     "pnpm": ">=9"
   },
   "packageManager": "pnpm@10.12.1+sha512.f0dda8580f0ee9481c5c79a1d927b9164f2c478e90992ad268bbb2465a736984391d6333d2c327913578b2804af33474ca554ba29c04a8b13060a717675ae3ac"


### PR DESCRIPTION
## Summary
- limit supported Node versions with an upper bound

## Testing
- `pnpm lint` *(fails: Error when performing the request)*

------
https://chatgpt.com/codex/tasks/task_b_684afbd8eb44832080722fd012f149b2