### PR TITLE
Fix invalid filename upload test

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -111,6 +111,7 @@ describe('API endpoints', () => {
   it('POST /upload rejects invalid filename', async () => {
     process.env.R2_BUCKET = 'b';
     process.env.JWT_SECRET = 's';
+    const sendSpy = vi.spyOn(S3Client.prototype, 'send').mockResolvedValue({});
     const token = sign({ id: 1 }, 's');
     const res = await request(app)
       .post('/upload')
@@ -118,5 +119,6 @@ describe('API endpoints', () => {
       .attach('model', Buffer.from('data'), { filename: '../evil.glb' });
     expect(res.status).toBe(400);
     expect(res.body).toEqual({ error: 'Invalid filename' });
+    expect(sendSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add S3 send spy in invalid filename test
- assert send was not called

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_684b00f85ac8832089b8e0edb176c8a3