### PR TITLE
fix: skip server start during vitest

### DIFF
--- a/server.js
+++ b/server.js
@@ -345,7 +345,7 @@ async function main() {
   return server;
 }
 
-if (process.env.NODE_ENV !== 'test') {
+if (process.env.NODE_ENV !== 'test' && !process.env.VITEST) {
   main().catch((err) => {
     console.error(err);
     process.exit(1);


### PR DESCRIPTION
## Summary
- avoid running main() when `process.env.VITEST` is set

## Testing
- `pnpm lint` *(fails: Error when performing the request to registry)*
- `pnpm test` *(fails: Error when performing the request to registry)*

------
https://chatgpt.com/codex/tasks/task_b_684b03deb3ac83208e2bfeb68fa15dc5