### PR TITLE
Add FRONTEND_ORIGINS support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,8 @@ AWS_REGION=
 R2_ENDPOINT=
 R2_BUCKET=
 
+# Allowed origins for CORS, comma-separated
+FRONTEND_ORIGINS=
+
 # Port for API server (default 3000; Render.com uses 10000)
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ pnpm start  # запуск API-сервера (опционально)
 
 Скопируй `.env.example` в `.env` и заполни нужные переменные: `JWT_SECRET` для подписи токенов, `VITE_ANALYTICS_ENDPOINT` для отправки аналитики и т.д.
 Для загрузки моделей из внешнего хранилища можно использовать переменную `VITE_MODEL_URL`.
+Для ограничения CORS задай переменную `FRONTEND_ORIGINS` со списком доменов через запятую.
 
 > **Важно:** приложение должно обслуживаться веб-сервером. Запускай его через `pnpm dev` или статический сервер. Простое открытие `dist/index.html` напрямую в браузере не сработает.
 
@@ -204,6 +205,7 @@ R2_ENDPOINT=https://<account>.r2.cloudflarestorage.com
 R2_BUCKET=my-bucket
 JWT_SECRET=super-secret
 JWT_MISSING_STATUS=
+FRONTEND_ORIGINS=
 ````
 
 #### Аутентификация

--- a/server.js
+++ b/server.js
@@ -17,7 +17,14 @@ import crypto from 'crypto';
 
 export const app = express();
 app.use(express.json());
-app.use(cors());
+const allowedOrigins = process.env.FRONTEND_ORIGINS
+  ? process.env.FRONTEND_ORIGINS.split(',').map((o) => o.trim()).filter(Boolean)
+  : undefined;
+if (allowedOrigins && allowedOrigins.length > 0) {
+  app.use(cors({ origin: allowedOrigins }));
+} else {
+  app.use(cors());
+}
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 10 * 1024 * 1024 }, // 10 MB


### PR DESCRIPTION
## Summary
- allow CORS origin list via `FRONTEND_ORIGINS`
- document `FRONTEND_ORIGINS` in README
- add `FRONTEND_ORIGINS` placeholder to `.env.example`

## Testing
- `pnpm lint` *(fails: fetch failed)*
- `pnpm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_684b046b376c8320a398e329316b0ec3