### PR TITLE
Ensure NODE_ENV is set during tests

### DIFF
--- a/tests/auth.routes.test.js
+++ b/tests/auth.routes.test.js
@@ -1,3 +1,5 @@
+process.env.NODE_ENV = 'test';
+
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import request from 'supertest';
 import { app, User } from '../server.js';

--- a/tests/model.schema.test.js
+++ b/tests/model.schema.test.js
@@ -1,3 +1,5 @@
+process.env.NODE_ENV = 'test';
+
 import { describe, it, expect } from 'vitest';
 import { Model } from '../server.js';
 

--- a/tests/models.test.js
+++ b/tests/models.test.js
@@ -1,3 +1,5 @@
+process.env.NODE_ENV = 'test';
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { app, Model } from '../server.js';

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,11 +1,11 @@
+process.env.NODE_ENV = 'test';
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { app, Model, main } from '../server.js';
 import mongoose from 'mongoose';
 import { sign } from './helpers/sign.js';
 import { S3Client } from '@aws-sdk/client-s3';
-
-process.env.NODE_ENV = 'test';
 
 describe('API endpoints', () => {
   let originalR2;


### PR DESCRIPTION
## Summary
- set `process.env.NODE_ENV = 'test'` before importing `server.js` in test files

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_684b054004588320802ca547744abd29