### PR TITLE
Implement role-based admin auth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ pnpm build    # production сборка
 pnpm preview  # проверка dist/
 
 # Открой http://localhost:5173/web-app-ar/ в браузере и нажми кнопку **Start AR** для запуска сцены
+# Для управления моделями зарегистрируй аккаунт с `role: 'admin'` через `/auth/register`
 ```
 
 ---
@@ -168,9 +169,9 @@ pnpm preview  # проверка dist/
 API сервера поддерживает регистрацию и вход пользователей.
 
 1. Задай `JWT_SECRET` в файле `.env`.
-2. `POST /auth/register` — регистрация пользователя `{username, email, password}`.
-3. `POST /auth/login` — получение токена `{ jwt }`.
-4. Для защищённых роутов отправляй заголовок `Authorization: Bearer <jwt>`.
+2. `POST /auth/register` — регистрация пользователя `{username, email, password, role}`. По умолчанию `role` = `user`.
+3. `POST /auth/login` — получение токена `{ jwt, role }`.
+4. Для защищённых роутов отправляй заголовок `Authorization: Bearer <jwt>`. Маршруты `PUT /api/models/:id`, `DELETE /api/models/:id` и `POST /upload` требуют роль `admin`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -215,9 +215,12 @@ FRONTEND_ORIGINS=
 #### Аутентификация
 
 1. Укажи `JWT_SECRET` в `.env` — ключ подписи JWT.
-2. Регистрация: `POST /auth/register` с JSON `{username, email, password}`.
-3. Вход: `POST /auth/login` — в ответ `{ jwt }`.
-4. Защищённые роуты требуют `Authorization: Bearer <jwt>`.
+2. Регистрация: `POST /auth/register` с JSON `{username, email, password, role}`.
+   Если `role` не указан, используется `user`.
+3. Вход: `POST /auth/login` — в ответ `{ jwt, role }`.
+4. Защищённые роуты требуют `Authorization: Bearer <jwt>`. Админские маршруты
+   (`PUT /api/models/:id`, `DELETE /api/models/:id`, `POST /upload`) доступны
+   только пользователям с ролью `admin`.
 
 Создайте бакет в панели Cloudflare R2 и укажите его имя в `R2_BUCKET`.
 
@@ -234,7 +237,7 @@ pnpm format
 2. Перейди по адресу `http://localhost:5173/web-app-ar/cp.html`.
 3. Укажи `VITE_API_BASE_URL` в `.env` (например, `http://localhost:3000`) и запусти API (`pnpm api`).
 
-После авторизации (регистрация и вход выполняются через форму страницы) доступны операции:
+После авторизации (регистрация и вход выполняются через форму страницы) доступны операции для пользователей с ролью `admin`:
 
 - **Upload** — отправка `.glb` файла на сервер (`POST /upload`).
 - **Edit** — изменение имени и индекса маркера (`PUT /api/models/:id`).

--- a/cp.html
+++ b/cp.html
@@ -134,7 +134,8 @@
         register,
         logout,
         isAuthenticated,
-        setToken,
+        setAuth,
+        getRole,
       } from './src/utils/auth.js';
       import {
         loadModels,
@@ -160,6 +161,7 @@
       async function refreshModels() {
         const list = document.getElementById('model-list');
         list.innerHTML = '';
+        const admin = getRole() === 'admin';
         try {
           const models = await loadModels();
           clearMessage();
@@ -169,18 +171,20 @@
             const info = document.createElement('span');
             info.textContent = `${m.name} (${m.url}) marker: ${m.markerIndex}`;
             li.appendChild(info);
-            const editBtn = document.createElement('button');
-            editBtn.textContent = 'Edit';
-            editBtn.className = 'button button-secondary';
-            const delBtn = document.createElement('button');
-            delBtn.textContent = 'Delete';
-            delBtn.className = 'button';
-            li.append(' ', editBtn, ' ', delBtn);
+            if (admin) {
+              const editBtn = document.createElement('button');
+              editBtn.textContent = 'Edit';
+              editBtn.className = 'button button-secondary';
+              const delBtn = document.createElement('button');
+              delBtn.textContent = 'Delete';
+              delBtn.className = 'button';
+              li.append(' ', editBtn, ' ', delBtn);
 
-            editBtn.addEventListener('click', () =>
-              showEditForm(li, modelId, m, editBtn),
-            );
-            delBtn.addEventListener('click', () => handleDelete(modelId));
+              editBtn.addEventListener('click', () =>
+                showEditForm(li, modelId, m, editBtn),
+              );
+              delBtn.addEventListener('click', () => handleDelete(modelId));
+            }
 
             list.appendChild(li);
           });
@@ -205,6 +209,7 @@
 
       function updateUI() {
         const logged = isAuthenticated();
+        const admin = logged && getRole() === 'admin';
         const loginFormEl = document.getElementById('login-form');
         const regFormEl = document.getElementById('register-form');
         if (logged) {
@@ -220,11 +225,14 @@
         document.getElementById('logout').classList.toggle('hidden', !logged);
         document
           .getElementById('upload-form')
-          .classList.toggle('hidden', !logged);
+          .classList.toggle('hidden', !admin);
         const msg = document.getElementById('upload-message');
-        if (logged) {
+        if (admin) {
           msg.style.display = 'none';
           msg.textContent = '';
+        } else if (logged) {
+          msg.textContent = 'Admin privileges required';
+          msg.style.display = 'block';
         } else {
           msg.textContent = 'Login required to upload models';
           msg.style.display = 'block';
@@ -236,11 +244,11 @@
         .addEventListener('submit', async (e) => {
           e.preventDefault();
           try {
-            const { jwt } = await login(
+            const { jwt, role } = await login(
               document.getElementById('login-email').value,
               document.getElementById('login-password').value,
             );
-            setToken(jwt);
+            setAuth(jwt, role);
             updateUI();
             await refreshModels();
             clearMessage();
@@ -254,12 +262,12 @@
         .addEventListener('submit', async (e) => {
           e.preventDefault();
           try {
-            const { jwt } = await register(
+            const { jwt, role } = await register(
               document.getElementById('reg-username').value,
               document.getElementById('reg-email').value,
               document.getElementById('reg-password').value,
             );
-            setToken(jwt);
+            setAuth(jwt, role);
             updateUI();
             await refreshModels();
             clearMessage();

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -6,8 +6,22 @@ export function setToken(token) {
   if (token) localStorage.setItem('jwt', token);
 }
 
+export function getRole() {
+  return localStorage.getItem('role') || 'user';
+}
+
+export function setRole(role) {
+  if (role) localStorage.setItem('role', role);
+}
+
+export function setAuth(token, role) {
+  setToken(token);
+  setRole(role);
+}
+
 export function logout() {
   localStorage.removeItem('jwt');
+  localStorage.removeItem('role');
 }
 
 export function isAuthenticated() {

--- a/tests/auth.routes.test.js
+++ b/tests/auth.routes.test.js
@@ -27,18 +27,22 @@ describe('auth endpoints', () => {
   it('POST /auth/register creates user', async () => {
     vi.spyOn(User, 'findOne').mockResolvedValue(null);
     vi.spyOn(bcrypt, 'hash').mockResolvedValue('h');
-    vi.spyOn(User, 'create').mockResolvedValue({ _id: 1 });
+    vi.spyOn(User, 'create').mockResolvedValue({ _id: 1, role: 'user' });
 
     const res = await request(app)
       .post('/auth/register')
       .send({ username: 'u', email: 'e', password: 'p' });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ jwt: sign({ id: 1 }, 'secret') });
+    expect(res.body).toEqual({ jwt: sign({ id: 1 }, 'secret'), role: 'user' });
   });
 
   it('POST /auth/login returns token', async () => {
-    vi.spyOn(User, 'findOne').mockResolvedValue({ _id: 1, passwordHash: 'h' });
+    vi.spyOn(User, 'findOne').mockResolvedValue({
+      _id: 1,
+      passwordHash: 'h',
+      role: 'user',
+    });
     vi.spyOn(bcrypt, 'compare').mockResolvedValue(true);
 
     const res = await request(app)
@@ -46,6 +50,6 @@ describe('auth endpoints', () => {
       .send({ email: 'e', password: 'p' });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ jwt: sign({ id: 1 }, 'secret') });
+    expect(res.body).toEqual({ jwt: sign({ id: 1 }, 'secret'), role: 'user' });
   });
 });


### PR DESCRIPTION
## Summary
- extend user schema with `role`
- add role handling to login/register
- add `requireRole` middleware
- protect admin routes
- persist user role in frontend and hide admin UI
- document admin features in README and AGENTS
- add tests for admin role logic

## Testing
- `npx prettier --write server.js src/utils/auth.js cp.html tests/auth.routes.test.js tests/models.test.js tests/server.test.js`
- `npx prettier --write README.md AGENTS.md`
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_684b27552bc08320a6f9493eba644a16