### PR TITLE
Add role-aware auth handling

### DIFF
--- a/cp.html
+++ b/cp.html
@@ -200,8 +200,10 @@
           await deleteModel(id);
           showMessage('Model deleted');
           await refreshModels();
-        } catch {
-          showMessage('Delete failed', true);
+        } catch (err) {
+          const msg =
+            err.message === 'Forbidden' ? 'Permission denied' : err.message;
+          showMessage(msg || 'Delete failed', true);
         }
       }
 
@@ -244,11 +246,11 @@
         .addEventListener('submit', async (e) => {
           e.preventDefault();
           try {
-            const { jwt, role } = await login(
+            const { jwt } = await login(
               document.getElementById('login-email').value,
               document.getElementById('login-password').value,
             );
-            setAuth(jwt, role);
+            setAuth(jwt);
             updateUI();
             await refreshModels();
             clearMessage();
@@ -262,12 +264,12 @@
         .addEventListener('submit', async (e) => {
           e.preventDefault();
           try {
-            const { jwt, role } = await register(
+            const { jwt } = await register(
               document.getElementById('reg-username').value,
               document.getElementById('reg-email').value,
               document.getElementById('reg-password').value,
             );
-            setAuth(jwt, role);
+            setAuth(jwt);
             updateUI();
             await refreshModels();
             clearMessage();
@@ -314,12 +316,15 @@
               headers,
               body: form,
             });
-            if (!res.ok) throw new Error('upload failed');
+            if (res.status === 403) throw new Error('Forbidden');
+            if (!res.ok) throw new Error('Upload failed');
             fileInput.value = '';
             await refreshModels();
             showMessage('Upload successful');
-          } catch {
-            showMessage('Upload failed', true);
+          } catch (err) {
+            const msg =
+              err.message === 'Forbidden' ? 'Permission denied' : err.message;
+            showMessage(msg || 'Upload failed', true);
           }
         });
 

--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
       const logoutBtn = document.getElementById('logout');
       const { startAR, modelParams } = await import('./src/ar-scene.js');
       const { loadModels } = await import('./src/utils/models.js');
-      const { login, register, logout, isAuthenticated, setToken } =
+      const { login, register, logout, isAuthenticated, setAuth } =
         await import('./src/utils/auth.js');
 
       let list = [];
@@ -214,7 +214,7 @@
             document.getElementById('login-email').value,
             document.getElementById('login-password').value,
           );
-          setToken(jwt);
+          setAuth(jwt);
           updateMenu();
         } catch (err) {
           alert(err.message);
@@ -229,7 +229,7 @@
             document.getElementById('register-email').value,
             document.getElementById('register-password').value,
           );
-          setToken(jwt);
+          setAuth(jwt);
           updateMenu();
         } catch (err) {
           alert(err.message);

--- a/server.js
+++ b/server.js
@@ -168,7 +168,10 @@ app.post('/auth/register', async (req, res) => {
       return res.status(400).json({ error: 'Email exists' });
     const passwordHash = await bcrypt.hash(password, 10);
     const user = await User.create({ username, email, passwordHash, role });
-    const jwt = signJwt({ id: user._id }, process.env.JWT_SECRET || '');
+    const jwt = signJwt(
+      { id: user._id, role: user.role },
+      process.env.JWT_SECRET || '',
+    );
     res.json({ jwt, role: user.role });
   } catch (e) {
     console.error(e);
@@ -192,7 +195,10 @@ app.post('/auth/login', async (req, res) => {
     if (!user) return res.status(400).json({ error: 'Invalid credentials' });
     const ok = await bcrypt.compare(password, user.passwordHash);
     if (!ok) return res.status(400).json({ error: 'Invalid credentials' });
-    const jwt = signJwt({ id: user._id }, process.env.JWT_SECRET || '');
+    const jwt = signJwt(
+      { id: user._id, role: user.role },
+      process.env.JWT_SECRET || '',
+    );
     res.json({ jwt, role: user.role });
   } catch (e) {
     console.error(e);

--- a/src/utils/editForm.js
+++ b/src/utils/editForm.js
@@ -42,8 +42,12 @@ export function showEditForm(li, id, m, btn) {
       });
       if (window.showMessage) window.showMessage('Model updated');
       if (window.refreshModels) await window.refreshModels();
-    } catch {
-      if (window.showMessage) window.showMessage('Update failed', true);
+    } catch (err) {
+      if (window.showMessage) {
+        const msg =
+          err.message === 'Forbidden' ? 'Permission denied' : err.message;
+        window.showMessage(msg || 'Update failed', true);
+      }
     }
   });
   btn.disabled = true;

--- a/src/utils/models.js
+++ b/src/utils/models.js
@@ -25,7 +25,12 @@ export async function updateModel(id, data) {
     headers: authHeaders(true),
     body: JSON.stringify(data),
   });
-  if (!res.ok) throw new Error('Update failed');
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    const msg =
+      data.error || (res.status === 403 ? 'Forbidden' : 'Update failed');
+    throw new Error(msg);
+  }
   return res.json().catch(() => ({}));
 }
 
@@ -34,6 +39,11 @@ export async function deleteModel(id) {
     method: 'DELETE',
     headers: authHeaders(),
   });
-  if (!res.ok) throw new Error('Delete failed');
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    const msg =
+      data.error || (res.status === 403 ? 'Forbidden' : 'Delete failed');
+    throw new Error(msg);
+  }
   return res.json().catch(() => ({}));
 }

--- a/tests/auth.routes.test.js
+++ b/tests/auth.routes.test.js
@@ -34,7 +34,10 @@ describe('auth endpoints', () => {
       .send({ username: 'u', email: 'e', password: 'p' });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ jwt: sign({ id: 1 }, 'secret'), role: 'user' });
+    expect(res.body).toEqual({
+      jwt: sign({ id: 1, role: 'user' }, 'secret'),
+      role: 'user',
+    });
   });
 
   it('POST /auth/login returns token', async () => {
@@ -50,6 +53,9 @@ describe('auth endpoints', () => {
       .send({ email: 'e', password: 'p' });
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ jwt: sign({ id: 1 }, 'secret'), role: 'user' });
+    expect(res.body).toEqual({
+      jwt: sign({ id: 1, role: 'user' }, 'secret'),
+      role: 'user',
+    });
   });
 });

--- a/tests/models.test.js
+++ b/tests/models.test.js
@@ -48,7 +48,7 @@ describe('model routes', () => {
 
   it('PUT /api/models/:id updates model', async () => {
     process.env.JWT_SECRET = 's';
-    const token = sign({ id: 1 }, 's');
+    const token = sign({ id: 1, role: 'admin' }, 's');
     vi.spyOn(User, 'findById').mockResolvedValue({ role: 'admin' });
     const spy = vi.spyOn(Model, 'findByIdAndUpdate').mockReturnValue({
       lean: vi.fn().mockResolvedValue({
@@ -87,7 +87,7 @@ describe('model routes', () => {
 
   it('PUT /api/models/:id with non-admin returns 403', async () => {
     process.env.JWT_SECRET = 's';
-    const token = sign({ id: 1 }, 's');
+    const token = sign({ id: 1, role: 'user' }, 's');
     vi.spyOn(User, 'findById').mockResolvedValue({ role: 'user' });
     const spy = vi
       .spyOn(Model, 'findByIdAndUpdate')
@@ -104,7 +104,7 @@ describe('model routes', () => {
 
   it('DELETE /api/models/:id removes model', async () => {
     process.env.JWT_SECRET = 's';
-    const token = sign({ id: 1 }, 's');
+    const token = sign({ id: 1, role: 'admin' }, 's');
     vi.spyOn(User, 'findById').mockResolvedValue({ role: 'admin' });
     const spy = vi.spyOn(Model, 'findByIdAndDelete').mockReturnValue({
       lean: vi.fn().mockResolvedValue({}),
@@ -133,7 +133,7 @@ describe('model routes', () => {
 
   it('DELETE /api/models/:id with non-admin returns 403', async () => {
     process.env.JWT_SECRET = 's';
-    const token = sign({ id: 1 }, 's');
+    const token = sign({ id: 1, role: 'user' }, 's');
     vi.spyOn(User, 'findById').mockResolvedValue({ role: 'user' });
     const spy = vi
       .spyOn(Model, 'findByIdAndDelete')

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -81,7 +81,7 @@ describe('API endpoints', () => {
     process.env.JWT_SECRET = 's';
     delete process.env.R2_BUCKET;
     vi.spyOn(User, 'findById').mockResolvedValue({ role: 'admin' });
-    const token = sign({ id: 1 }, 's');
+    const token = sign({ id: 1, role: 'admin' }, 's');
     const res = await request(app)
       .post('/upload')
       .set('Authorization', `Bearer ${token}`)
@@ -98,7 +98,7 @@ describe('API endpoints', () => {
     vi.spyOn(S3Client.prototype, 'send').mockResolvedValue({});
     vi.spyOn(User, 'findById').mockResolvedValue({ role: 'admin' });
     const updateSpy = vi.spyOn(Model, 'updateOne').mockResolvedValue({});
-    const token = sign({ id: 1 }, 's');
+    const token = sign({ id: 1, role: 'admin' }, 's');
     const res = await request(app)
       .post('/upload')
       .set('Authorization', `Bearer ${token}`)
@@ -117,7 +117,7 @@ describe('API endpoints', () => {
     process.env.R2_BUCKET = 'b';
     process.env.JWT_SECRET = 's';
     vi.spyOn(User, 'findById').mockResolvedValue({ role: 'admin' });
-    const token = sign({ id: 1 }, 's');
+    const token = sign({ id: 1, role: 'admin' }, 's');
     const big = Buffer.alloc(11 * 1024 * 1024, 'a');
     const res = await request(app)
       .post('/upload')
@@ -131,7 +131,7 @@ describe('API endpoints', () => {
     process.env.JWT_SECRET = 's';
     const sendSpy = vi.spyOn(S3Client.prototype, 'send').mockResolvedValue({});
     vi.spyOn(User, 'findById').mockResolvedValue({ role: 'admin' });
-    const token = sign({ id: 1 }, 's');
+    const token = sign({ id: 1, role: 'user' }, 's');
     const res = await request(app)
       .post('/upload')
       .set('Authorization', `Bearer ${token}`)
@@ -145,7 +145,7 @@ describe('API endpoints', () => {
     process.env.R2_BUCKET = 'b';
     process.env.JWT_SECRET = 's';
     vi.spyOn(User, 'findById').mockResolvedValue({ role: 'user' });
-    const token = sign({ id: 1 }, 's');
+    const token = sign({ id: 1, role: 'user' }, 's');
     const res = await request(app)
       .post('/upload')
       .set('Authorization', `Bearer ${token}`)


### PR DESCRIPTION
## Summary
- decode JWT payload to get user role
- propagate role from decoded token on login
- block actions in UI when lacking permission
- include role in JWT payload returned by API
- handle forbidden errors on model operations
- update tests for new token format

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684b2d5d4fa48320b31194c8c1a9bb3c