### PR TITLE
feat: configurable rate limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,5 +22,8 @@ R2_BUCKET=
 # Allowed origins for CORS, comma-separated
 FRONTEND_ORIGINS=
 
+# Maximum requests per 15 minutes (default 100)
+RATE_LIMIT_MAX=
+
 # Port for API server (default 3000; Render.com uses 10000)
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ pnpm start  # запуск API-сервера (опционально)
    - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`
    - `R2_ENDPOINT`, `R2_BUCKET`
    - `FRONTEND_ORIGINS` – список разрешённых доменов для CORS
+   - `RATE_LIMIT_MAX` – максимальное число запросов за 15 минут (по умолчанию 100)
    - `PORT` – укажи `10000` (Render запускает приложение на этом порту)
 5. Сохрани настройки и запусти деплой. После успешного билда сервис будет доступен по адресу вида `https://<name>.onrender.com`.
 
@@ -211,6 +212,7 @@ R2_BUCKET=my-bucket
 JWT_SECRET=super-secret
 JWT_MISSING_STATUS=
 FRONTEND_ORIGINS=
+RATE_LIMIT_MAX=
 ````
 
 #### Аутентификация
@@ -222,8 +224,9 @@ FRONTEND_ORIGINS=
 4. Защищённые роуты требуют `Authorization: Bearer <jwt>`. Админские маршруты
    (`PUT /api/models/:id`, `DELETE /api/models/:id`, `POST /upload`) доступны
    только пользователям с ролью `admin`.
-   На эти маршруты также накладывается ограничение скорости
-   (100 запросов за 15 минут) через `express-rate-limit`.
+  На эти маршруты также накладывается ограничение скорости
+  через `express-rate-limit` (по умолчанию 100 запросов за 15 минут,
+  значение можно изменить через `RATE_LIMIT_MAX`).
 
 Создайте бакет в панели Cloudflare R2 и укажите его имя в `R2_BUCKET`.
 

--- a/server.js
+++ b/server.js
@@ -28,10 +28,8 @@ if (allowedOrigins && allowedOrigins.length > 0) {
 } else {
   app.use(cors());
 }
-export const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 100,
-});
+const max = parseInt(process.env.RATE_LIMIT_MAX, 10) || 100;
+export const limiter = rateLimit({ windowMs: 15 * 60 * 1000, max });
 const upload = multer({
   storage: multer.memoryStorage(),
   limits: { fileSize: 10 * 1024 * 1024 }, // 10 MB


### PR DESCRIPTION
## Summary
- support RATE_LIMIT_MAX env variable
- document RATE_LIMIT_MAX in `.env.example` and README

## Testing
- `pnpm test` *(fails: Error when performing the request to registry)*
- `pnpm lint` *(fails: Error when performing the request to registry)*

------
https://chatgpt.com/codex/tasks/task_b_684b35dff7d88320939105fba37e607c