### PR TITLE
Fix invalid filename upload handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -270,8 +270,10 @@ app.post(
       if (err) {
         if (err.code === 'LIMIT_FILE_SIZE')
           return res.status(413).json({ error: 'File too large' });
-        if (err.code === 'INVALID_FILENAME')
-          return res.status(400).json({ error: 'Invalid filename' });
+        if (err.code === 'INVALID_FILENAME') {
+          res.status(400).json({ error: 'Invalid filename' });
+          return res.end();
+        }
         return res.status(400).json({ error: 'Upload failed' });
       }
       next();

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -135,7 +135,10 @@ describe('API endpoints', () => {
     const res = await request(app)
       .post('/upload')
       .set('Authorization', `Bearer ${token}`)
-      .attach('model', Buffer.from('data'), { filename: '../evil.glb' });
+      .attach('model', Buffer.from('data'), {
+        filename: '../evil.glb',
+        contentType: 'model/gltf-binary',
+      });
     expect(res.status).toBe(400);
     expect(res.body).toEqual({ error: 'Invalid filename' });
     expect(sendSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- end the response when the upload filter rejects an invalid filename
- include content type for invalid filename test

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_684b377efd008320b60c01af63327881