### PR TITLE
Expose ids in model list

### DIFF
--- a/server.js
+++ b/server.js
@@ -234,7 +234,9 @@ app.post('/auth/login', async (req, res) => {
 
 app.get('/api/models', async (req, res) => {
   try {
-    const list = await Model.find().select('name url markerIndex -_id').lean();
+    const list = await Model.find()
+      .select('name url markerIndex')
+      .lean();
     res.json(list);
   } catch (e) {
     console.error(e);

--- a/src/cp.js
+++ b/src/cp.js
@@ -124,14 +124,17 @@ function renderModels(list) {
   modelsList.innerHTML = '';
   const admin = getRole() === 'admin';
   list.forEach((m) => {
-    const id = m._id || m.id;
+    const id = m._id;
     const li = document.createElement('li');
+    if (id) li.dataset.id = id;
     li.textContent = `${m.name} (${m.url}) - marker ${m.markerIndex}`;
     if (admin && id) {
       const editBtn = document.createElement('button');
       editBtn.textContent = 'Edit';
       editBtn.className = 'button button-primary ml-2';
-      editBtn.addEventListener('click', () => showEditForm(li, id, m, editBtn));
+      editBtn.addEventListener('click', () =>
+        showEditForm(li, li.dataset.id, m, editBtn),
+      );
       li.appendChild(editBtn);
 
       const delBtn = document.createElement('button');
@@ -140,7 +143,7 @@ function renderModels(list) {
       delBtn.addEventListener('click', async () => {
         if (!confirm('Delete this model?')) return;
         try {
-          await deleteModel(id);
+          await deleteModel(li.dataset.id);
           showMessage('Model deleted');
           await refreshModels();
         } catch (err) {

--- a/tests/models.test.js
+++ b/tests/models.test.js
@@ -22,14 +22,16 @@ describe('model routes', () => {
   it('GET /api/models returns list', async () => {
     vi.spyOn(Model, 'find').mockReturnValue({
       select: vi.fn().mockReturnThis(),
-      lean: vi
-        .fn()
-        .mockResolvedValue([{ name: 'm1', url: 'm1.glb', markerIndex: 0 }]),
+      lean: vi.fn().mockResolvedValue([
+        { _id: '1', name: 'm1', url: 'm1.glb', markerIndex: 0 },
+      ]),
     });
 
     const res = await request(app).get('/api/models');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual([{ name: 'm1', url: 'm1.glb', markerIndex: 0 }]);
+    expect(res.body).toEqual([
+      { _id: '1', name: 'm1', url: 'm1.glb', markerIndex: 0 },
+    ]);
   });
 
   it('GET /api/models/:id returns single model', async () => {


### PR DESCRIPTION
## Summary
- return `_id` in model list API
- update cp.js to preserve each `_id` when editing or deleting
- adjust model list test to expect `_id`

## Testing
- `pnpm lint` *(fails: fetch from registry blocked)*
- `pnpm test` *(fails: fetch from registry blocked)*

------
https://chatgpt.com/codex/tasks/task_b_684b443dae5c83209c2d5f3a8eac7f60