### PR TITLE
Mock DB operations in file upload tests

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -130,6 +130,7 @@ describe('API endpoints', () => {
     process.env.R2_BUCKET = 'b';
     process.env.JWT_SECRET = 's';
     const sendSpy = vi.spyOn(S3Client.prototype, 'send').mockResolvedValue({});
+    vi.spyOn(Model, 'updateOne').mockResolvedValue({});
     vi.spyOn(User, 'findOne').mockResolvedValue({ role: 'admin' });
     const token = sign({ id: '1', role: 'user' }, 's');
     const res = await request(app)
@@ -195,8 +196,9 @@ describe('API endpoints', () => {
     process.env.RATE_LIMIT_MAX = '2';
     process.env.R2_BUCKET = 'b';
     process.env.JWT_SECRET = 's';
-    const { app: rlApp, User: RLUser } = await import('../server.js');
+    const { app: rlApp, User: RLUser, Model: RLModel } = await import('../server.js');
     vi.spyOn(S3Client.prototype, 'send').mockResolvedValue({});
+    vi.spyOn(RLModel, 'updateOne').mockResolvedValue({});
     vi.spyOn(RLUser, 'findOne').mockResolvedValue({ role: 'admin' });
     const token = sign({ id: '1', role: 'admin' }, 's');
     await request(rlApp)


### PR DESCRIPTION
## Summary
- mock `Model.updateOne` in the invalid filename and rate limit tests
- ensure mocks are restored after each test

## Testing
- `pnpm test` *(fails: Request was cancelled because internet access is disabled)*

------
https://chatgpt.com/codex/tasks/task_b_684b4ad8d0348320beb504c8df9f502a