### PR TITLE
Update upload filename test for Multer behavior

### DIFF
--- a/server.js
+++ b/server.js
@@ -81,6 +81,10 @@ function signJwt(payload, secret) {
   return jwt.sign(payload, secret, { noTimestamp: true });
 }
 
+// Multer sanitizes `file.originalname` using `path.basename` before our
+// `fileFilter` runs. `isValidFilename` therefore checks the already sanitized
+// value. This means paths like "../model.glb" become "model.glb" and are
+// considered valid unless additional validation is done.
 function isValidFilename(name) {
   return (
     typeof name === 'string' &&


### PR DESCRIPTION
## Summary
- update `/upload` test to expect sanitized filename
- document Multer filename sanitization in `isValidFilename`

## Testing
- `pnpm test` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_b_684b4bd535ec8320979cd4beb0db1dee