### PR TITLE
Add ObjectId validation middleware

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,7 +2,7 @@ import dotenv from 'dotenv';
 dotenv.config();
 import express from 'express';
 import cors from 'cors';
-import mongoose from 'mongoose';
+import mongoose, { isValidObjectId } from 'mongoose';
 mongoose.set('bufferCommands', false);
 mongoose.set('bufferTimeoutMS', 0);
 import multer from 'multer';
@@ -288,6 +288,9 @@ app.get('/api/models', async (req, res) => {
 });
 
 export async function getModelById(req, res) {
+  if (!isValidObjectId(req.params.id)) {
+    return res.status(400).json({ error: 'Invalid ID' });
+  }
   try {
     const model = await Model.findById(req.params.id).lean();
     if (!model) return res.status(404).json({ error: 'Model not found' });
@@ -302,6 +305,9 @@ export async function updateModel(req, res) {
   const { name, url, markerIndex } = req.body || {};
   if (!name || !url || typeof markerIndex !== 'number') {
     return res.status(400).json({ error: 'Missing fields' });
+  }
+  if (!isValidObjectId(req.params.id)) {
+    return res.status(400).json({ error: 'Invalid ID' });
   }
   try {
     const updated = await Model.findByIdAndUpdate(
@@ -318,6 +324,9 @@ export async function updateModel(req, res) {
 }
 
 export async function deleteModel(req, res) {
+  if (!isValidObjectId(req.params.id)) {
+    return res.status(400).json({ error: 'Invalid ID' });
+  }
   try {
     const doc = await Model.findByIdAndDelete(req.params.id).lean();
     if (!doc) return res.status(404).json({ error: 'Model not found' });

--- a/tests/models.test.js
+++ b/tests/models.test.js
@@ -48,6 +48,14 @@ describe('model routes', () => {
     expect(res.body).toEqual({ name: 'm', url: 'm.glb', markerIndex: 1 });
   });
 
+  it('GET /api/models/:id with invalid id returns 400', async () => {
+    const spy = vi.spyOn(Model, 'findById');
+    const res = await request(app).get('/api/models/bad');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid ID' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   it('PUT /api/models/:id updates model', async () => {
     process.env.JWT_SECRET = 's';
     const token = sign({ id: '1', role: 'admin' }, 's');
@@ -104,6 +112,24 @@ describe('model routes', () => {
     expect(spy).not.toHaveBeenCalled();
   });
 
+  it('PUT /api/models/:id with invalid id returns 400', async () => {
+    process.env.JWT_SECRET = 's';
+    const token = sign({ id: '1', role: 'admin' }, 's');
+    vi.spyOn(User, 'findOne').mockResolvedValue({ role: 'admin' });
+    const spy = vi
+      .spyOn(Model, 'findByIdAndUpdate')
+      .mockReturnValue({ lean: vi.fn() });
+
+    const res = await request(app)
+      .put('/api/models/bad')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ name: 'x', url: 'x.glb', markerIndex: 2 });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid ID' });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   it('DELETE /api/models/:id removes model', async () => {
     process.env.JWT_SECRET = 's';
     const token = sign({ id: '1', role: 'admin' }, 's');
@@ -146,6 +172,23 @@ describe('model routes', () => {
       .set('Authorization', `Bearer ${token}`);
 
     expect(res.status).toBe(403);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('DELETE /api/models/:id with invalid id returns 400', async () => {
+    process.env.JWT_SECRET = 's';
+    const token = sign({ id: '1', role: 'admin' }, 's');
+    vi.spyOn(User, 'findOne').mockResolvedValue({ role: 'admin' });
+    const spy = vi
+      .spyOn(Model, 'findByIdAndDelete')
+      .mockReturnValue({ lean: vi.fn() });
+
+    const res = await request(app)
+      .delete('/api/models/bad')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Invalid ID' });
     expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- validate params for ObjectId in model routes
- test invalid id responses

## Testing
- `pnpm format` *(fails: Request was cancelled)*
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684b57be21c48320b543590035056315