### PR TITLE
Fix API base URL in auth tests

### DIFF
--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -31,8 +31,9 @@ describe('login', () => {
   it('sends POST to /auth/login', async () => {
     fetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({}) });
     await login('user@example.com', 'pass');
+    const base = import.meta.env.VITE_API_BASE_URL || '';
     expect(fetch).toHaveBeenCalledWith(
-      '/auth/login',
+      base + '/auth/login',
       expect.objectContaining({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -55,8 +56,9 @@ describe('register', () => {
   it('sends POST to /auth/register', async () => {
     fetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({}) });
     await register('u', 'e', 'p');
+    const base = import.meta.env.VITE_API_BASE_URL || '';
     expect(fetch).toHaveBeenCalledWith(
-      '/auth/register',
+      base + '/auth/register',
       expect.objectContaining({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- adjust `tests/auth.test.js` to honor `VITE_API_BASE_URL`

## Testing
- `pnpm test` *(fails: attempting to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_684bcfd04ef08320b263b1522865f63e