### PR TITLE
Implement cleanup for rate limit middleware

### DIFF
--- a/lib/express-rate-limit/index.js
+++ b/lib/express-rate-limit/index.js
@@ -1,8 +1,20 @@
 export default function rateLimit(options = {}) {
   const windowMs = options.windowMs || 15 * 60 * 1000;
   const max = options.max ?? options.limit ?? 5; // default max if not given
+  const cleanupIntervalMs = options.cleanupIntervalMs || 60 * 1000;
   const store = new Map();
-  return function limiter(req, res, next) {
+
+  function cleanup() {
+    const now = Date.now();
+    for (const [key, entry] of store) {
+      if (entry.expires <= now) store.delete(key);
+    }
+  }
+
+  const interval = setInterval(cleanup, cleanupIntervalMs);
+  if (interval.unref) interval.unref();
+
+  function limiter(req, res, next) {
     const key = req.ip || req.headers['x-forwarded-for'] || 'default';
     const now = Date.now();
     let entry = store.get(key);
@@ -17,5 +29,10 @@ export default function rateLimit(options = {}) {
       return;
     }
     next();
-  };
+  }
+
+  limiter.stop = () => clearInterval(interval);
+  limiter._store = store; // exposed for tests
+
+  return limiter;
 }


### PR DESCRIPTION
## Summary
- periodically remove expired entries in express-rate-limit
- allow interval cleanup to be stopped
- test cleanup logic using fake timers

## Testing
- `pnpm lint` *(fails: request to registry.npmjs.org blocked)*
- `pnpm test` *(fails: request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_b_684c09b45ec083208e37b9bf2ad61ca7