### PR TITLE
Add nvm check to setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ git clone <repo-url>
 cd <project-name>
 nvm install  # установит Node.js из .nvmrc (проект требует Node.js 18–21)
 nvm use
-sh scripts/setup-node.sh # убедись в поддерживаемой версии перед pnpm install
+sh scripts/setup-node.sh # проверит наличие nvm и подходящую версию Node.js
 pnpm install
 # скопируй пример конфигурации и заполни значения
 cp .env.example .env
@@ -81,6 +81,8 @@ pnpm build # production сборка
 pnpm preview # предпросмотр dist/
 pnpm start  # запуск API-сервера (опционально)
 ```
+
+> Скрипт `setup-node.sh` завершится с подсказкой по установке `nvm`, если менеджер не найден.
 
 Этот проект использует **pnpm** как менеджер пакетов. В репозитории хранится `pnpm-lock.yaml`; файл `package-lock.json` не используется.
 В `.gitattributes` прописано `pnpm-lock.yaml merge=ours`, поэтому при слияниях предпочтение отдаётся локальному lockfile.

--- a/scripts/setup-node.sh
+++ b/scripts/setup-node.sh
@@ -1,6 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
+# Ensure nvm is available
+if ! command -v nvm >/dev/null; then
+  cat <<'EOF'
+nvm (Node Version Manager) is required but was not found.
+Install it manually and restart the terminal:
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+EOF
+  exit 1
+fi
+
 # Check if Node.js is installed
 if ! command -v node >/dev/null; then
   echo "Node.js not found. Installing Node 20 with nvm..."


### PR DESCRIPTION
## Summary
- ensure `scripts/setup-node.sh` verifies `nvm` exists and prints install hint
- document new behavior in README

## Testing
- `pnpm test` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_b_684c1051acfc8320af58dc17467d683a