### PR TITLE
Add forcePathStyle for Cloudflare R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ RATE_LIMIT_MAX=
    выполнить вход.
 
 Создайте бакет в панели Cloudflare R2 и укажите его имя в `R2_BUCKET`.
+При инициализации `S3Client` для работы с R2 необходимо передавать опцию
+`forcePathStyle: true`.
 
 ```bash
 pnpm lint

--- a/server.js
+++ b/server.js
@@ -53,6 +53,7 @@ const s3 = new S3Client({
   },
   endpoint: process.env.R2_ENDPOINT,
   region: process.env.AWS_REGION || 'us-east-1',
+  forcePathStyle: true,
 });
 
 const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/ar';


### PR DESCRIPTION
## Summary
- enable `forcePathStyle` when creating the S3 client
- document this Cloudflare R2 requirement in README

## Testing
- `pnpm test` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_b_684c116da5e08320834ad6a696dbfe31