### PR TITLE
Fix secrets for Vite build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,8 @@ jobs:
         env:
           NODE_ENV: production
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+          VITE_MODEL_URL: ${{ secrets.VITE_MODEL_URL }}
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,6 +30,8 @@ jobs:
       - run: pnpm build
         env:
           NODE_ENV: production
+          VITE_API_BASE_URL: ${{ secrets.VITE_API_BASE_URL }}
+          VITE_MODEL_URL: ${{ secrets.VITE_MODEL_URL }}
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist


### PR DESCRIPTION
## Summary
- inject Vite environment secrets into deployment workflows

## Testing
- `pnpm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_684c49cf9688832091b3cae8cfc6373a