### PR TITLE
Add helmet middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "mind-ar": "^1.2.5",
     "mongoose": "^8.3.0",
     "multer": "^2.0.1",
+    "helmet": "^7.0.0",
     "three": "0.152.2",
     "vite": "5.4.19",
     "express-rate-limit": "file:lib/express-rate-limit"

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ mongoose.set('bufferCommands', false);
 mongoose.set('bufferTimeoutMS', 0);
 import multer from 'multer';
 import bcrypt from 'bcryptjs';
+import helmet from 'helmet';
 import {
   S3Client,
   PutObjectCommand,
@@ -20,6 +21,7 @@ import rateLimit from 'express-rate-limit';
 
 export const app = express();
 app.use(express.json());
+app.use(helmet());
 const allowedOrigins = process.env.FRONTEND_ORIGINS
   ? process.env.FRONTEND_ORIGINS.split(',')
       .map((o) => o.trim())


### PR DESCRIPTION
## Summary
- add helmet dependency
- use helmet in Express server

## Testing
- `node -v`
- `pnpm --version` *(fails: registry unavailable)*

------
https://chatgpt.com/codex/tasks/task_b_684c52ca9b1883209f715c666d4b99f6