### PR TITLE
Sanitize MongoDB connection log

### DIFF
--- a/server.js
+++ b/server.js
@@ -464,7 +464,8 @@ app.get('/model/:filename', async (req, res) => {
 async function main() {
   try {
     await mongoose.connect(mongoUri);
-    console.log(`✅ [mongo] connected to ${mongoUri}`);
+    const mongoHost = new URL(mongoUri).host;
+    console.log(`✅ [mongo] connected to ${mongoHost}`);
     await validateMongoSchema();
   } catch (err) {
     console.error(


### PR DESCRIPTION
## Summary
- sanitize MongoDB URI before logging connection message

## Testing
- `pnpm lint` *(fails: unable to download packages)*
- `pnpm test` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_b_684c5a12f3ec8320986dd6ab7a22660a