### PR TITLE
Skip R2 check in tests

### DIFF
--- a/server.js
+++ b/server.js
@@ -74,16 +74,18 @@ const s3 = new S3Client({
   forcePathStyle: true,
 });
 
-// Test R2 connectivity on startup
-(async () => {
-  try {
-    const resp = await s3.send(new ListBucketsCommand({}));
-    const names = resp.Buckets?.map((b) => b.Name) || [];
-    console.log('✅ [r2] connection OK, buckets:', names.join(', '));
-  } catch (err) {
-    console.error('❌ [r2] connection error:', err.message);
-  }
-})();
+// Test R2 connectivity on startup (skipped in tests)
+if (process.env.NODE_ENV !== 'test') {
+  (async () => {
+    try {
+      const resp = await s3.send(new ListBucketsCommand({}));
+      const names = resp.Buckets?.map((b) => b.Name) || [];
+      console.log('✅ [r2] connection OK, buckets:', names.join(', '));
+    } catch (err) {
+      console.error('❌ [r2] connection error:', err.message);
+    }
+  })();
+}
 
 const mongoUri = process.env.MONGODB_URI || 'mongodb://localhost:27017/ar';
 

--- a/tests/r2-connect.test.js
+++ b/tests/r2-connect.test.js
@@ -1,0 +1,21 @@
+process.env.NODE_ENV = 'test';
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { S3Client } from '@aws-sdk/client-s3';
+
+describe('R2 connectivity check', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('skips ListBucketsCommand when NODE_ENV is test', async () => {
+    const spy = vi.spyOn(S3Client.prototype, 'send').mockResolvedValue({});
+    await import('../server.js');
+    expect(spy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- run the R2 connectivity IIFE only outside test mode
- add regression test to ensure `ListBucketsCommand` isn't called when `NODE_ENV` is `test`

## Testing
- `pnpm lint` *(fails: Request was cancelled - proxy response 403)*
- `pnpm test` *(fails: Request was cancelled - proxy response 403)*

------
https://chatgpt.com/codex/tasks/task_b_684c5a7cd44c8320b212bb63ff942308