### PR TITLE
Fix auth route tests

### DIFF
--- a/tests/auth.routes.test.js
+++ b/tests/auth.routes.test.js
@@ -35,7 +35,7 @@ describe('auth endpoints', () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
-      jwt: sign({ id: 1, role: 'user' }, 'secret'),
+      jwt: sign({ id: '1', role: 'user' }, 'secret'),
       role: 'user',
     });
   });
@@ -54,7 +54,7 @@ describe('auth endpoints', () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({
-      jwt: sign({ id: 1, role: 'user' }, 'secret'),
+      jwt: sign({ id: '1', role: 'user' }, 'secret'),
       role: 'user',
     });
   });
@@ -65,7 +65,7 @@ describe('auth endpoints', () => {
       email: 'e',
       role: 'user',
     });
-    const token = sign({ id: 1, role: 'user' }, 'secret');
+    const token = sign({ id: '1', role: 'user' }, 'secret');
 
     const res = await request(app)
       .get('/api/me')


### PR DESCRIPTION
## Summary
- update token signing helpers in `auth.routes.test.js` to use string ID's

## Testing
- `pnpm test` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_b_684c6303bd988320961cb9ba58bf7af3