### PR TITLE
Apply rate limiting to auth endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -255,7 +255,7 @@ async function validateMongoSchema() {
   }
 }
 
-app.post('/auth/register', async (req, res) => {
+app.post('/auth/register', limiter, async (req, res) => {
   const { username, email, password, role = 'user' } = req.body || {};
   if (!email || !password)
     return res.status(400).json({ error: 'Missing fields' });
@@ -282,7 +282,7 @@ app.post('/auth/register', async (req, res) => {
   }
 });
 
-app.post('/auth/login', async (req, res) => {
+app.post('/auth/login', limiter, async (req, res) => {
   const { email, password } = req.body || {};
   if (!email || !password)
     return res.status(400).json({ error: 'Missing fields' });


### PR DESCRIPTION
## Summary
- protect `/auth/login` and `/auth/register` with the existing limiter
- test that the login route is rate limited

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_684c644a03148320abbe651edfa0042b