### PR TITLE
Improve API base url fallback

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -53,7 +53,13 @@ export function isAuthenticated() {
   return Boolean(getToken());
 }
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+let API_BASE = (import.meta.env.VITE_API_BASE_URL || '').trim();
+if (!API_BASE) {
+  console.warn(
+    'VITE_API_BASE_URL is empty; falling back to location.origin',
+  );
+  API_BASE = typeof location !== 'undefined' ? location.origin : '';
+}
 
 async function sendAuth(path, payload, failMsg) {
   const url = API_BASE + path;

--- a/src/utils/models.js
+++ b/src/utils/models.js
@@ -1,4 +1,10 @@
-const API_BASE = import.meta.env.VITE_API_BASE_URL || '';
+let API_BASE = (import.meta.env.VITE_API_BASE_URL || '').trim();
+if (!API_BASE) {
+  console.warn(
+    'VITE_API_BASE_URL is empty; falling back to location.origin',
+  );
+  API_BASE = typeof location !== 'undefined' ? location.origin : '';
+}
 const DEFAULT_MODEL_URL = import.meta.env.VITE_MODEL_URL;
 
 if (API_BASE.endsWith('/api')) {


### PR DESCRIPTION
## Summary
- warn if `VITE_API_BASE_URL` is empty and fall back to `location.origin`
- same warning for authentication helper

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684c87773eb48320a94801f5787e206c