### PR TITLE
Add usage details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,23 @@ After running, the file will be saved as `assets/model.glb`.
 The application expects `assets/model.glb` to exist when served. A
 `model-placeholder.txt` file is included so the directory exists in the
 repository, but it will not be used by the application.
+
+## Serving the site
+
+Before starting, make sure the 3D model has been downloaded using the
+`assets/download_models.sh` script as shown above.  The project is a
+fully static site and can be served with any static file server.  One easy
+option is [`http-server`](https://www.npmjs.com/package/http-server):
+
+```sh
+npx http-server .
+```
+
+Open the printed URL in your browser to view the application.
+
+## API endpoint
+
+The JavaScript bundles expect an API to be reachable at a base URL provided
+via the `VITE_API_BASE_URL` environment variable at build time.  If this
+variable is empty, the code falls back to `location.origin`.  Ensure your API
+is accessible from that URL under the `/api` path before launching the site.


### PR DESCRIPTION
## Summary
- add instructions for serving the site with `http-server`
- mention downloading `.glb` assets before starting the app
- explain the `VITE_API_BASE_URL` configuration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684c8e6f400c832084a8099b5babfd81