### PR TITLE
Improve model download docs and add startup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,27 @@
 # Web AR Application
 
-This repository contains a small web application for displaying an AR model.
-Large assets, such as the 3D model used by the page, are not kept in the
-repository. Instead they can be fetched using the provided script.
+This repository contains a small web application for displaying an AR model. Large assets, such as the 3D model used by the page, are not kept in the repository. They can be fetched using the provided helper script.
 
 ## Downloading the model
 
-The `assets/download_models.sh` script downloads the required `model.glb`
-file. Set the `MODEL_URL` environment variable to the URL where the model is
-hosted and run the script:
+Run `assets/download_models.sh` from the project root to download the required `model.glb`. The URL of the model is taken from the `MODEL_URL` environment variable. If it is not set, a placeholder URL is used.
 
 ```sh
 MODEL_URL=https://example.com/path/to/model.glb ./assets/download_models.sh
+```
+
+For Cloudflare R2 storage you might use:
+
+```sh
+MODEL_URL=https://<account>.r2.cloudflarestorage.com/<bucket>/model.glb ./assets/download_models.sh
 ```
 
 After running, the file will be saved as `assets/model.glb`.
 
 ## Required assets
 
-The application expects `assets/model.glb` to exist when served. A
-`model-placeholder.txt` file is included so the directory exists in the
-repository, but it will not be used by the application.
+The application expects `assets/model.glb` to exist when served. A `model-placeholder.txt` file is included so the directory exists in the repository but it is not used by the application.
+
+## Running locally
+
+Use the `serve.sh` script to start a small development server. It checks for `assets/model.glb` and downloads it automatically if missing before launching `python3 -m http.server`.

--- a/serve.sh
+++ b/serve.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+# Simple helper to run a local development server.
+# Automatically downloads the model if it is missing.
+
+set -e
+
+if [ ! -f assets/model.glb ]; then
+    echo "assets/model.glb not found. Attempting download..."
+    ./assets/download_models.sh
+fi
+
+echo "Starting server at http://localhost:8000"
+python3 -m http.server 8000


### PR DESCRIPTION
## Summary
- update instructions for running `assets/download_models.sh`
- add `serve.sh` script that downloads `model.glb` if necessary and starts a dev server

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_684c8e74fda88320bbba6952e1417742