### PR TITLE
Add base path env setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ VITE_MODEL_URL=
 # Base URL for API requests when running or building the CMS/front-end
 # Do not include the trailing `/api`
 VITE_API_BASE_URL=
+# Base path for GitHub Pages deployment
+# Must start and end with a slash
+VITE_BASE_PATH=/web-app-ar/
 # Cloudflare R2 / S3 credentials
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ pnpm start  # запуск API-сервера (опционально)
    > ⚠️ Значение `base` должно совпадать с названием репозитория на GitHub.
    > Обязательно укажите `build.target = 'esnext'`, иначе топ-левел `await` не
    > будет работать на GitHub Pages.
+   Можно также указать путь через переменную `VITE_BASE_PATH`, например
+   `VITE_BASE_PATH=/my-repo/ pnpm build`. Если переменная не задана,
+   используется значение по умолчанию `/web-app-ar/`.
 2. Укажи URL бэкенда через `VITE_API_BASE_URL`, чтобы страница CMS могла обращаться к API:
    ```bash
    VITE_API_BASE_URL=https://example.com pnpm build
@@ -154,6 +157,7 @@ pnpm start  # запуск API-сервера (опционально)
 - `RATE_LIMIT_MAX` – максимальное число запросов за 15 минут (по умолчанию 100)
 - `VITE_API_BASE_URL` – base URL for API requests when running or building the CMS/front‑end
 - не добавляй `/api`, просто `https://example.com`
+- `VITE_BASE_PATH` – базовый путь для GitHub Pages (например, `/web-app-ar/`)
 - `PORT` – укажи `10000` (Render запускает приложение на этом порту)
 
 5. Сохрани настройки и запусти деплой. После успешного билда сервис будет доступен по адресу вида `https://<name>.onrender.com`.

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,7 @@ import postcss from './src/postcss.config.js';
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   return {
-    base: '/web-app-ar/',
+    base: env.VITE_BASE_PATH || '/web-app-ar/',
     build: {
       target: 'esnext',
       rollupOptions: {


### PR DESCRIPTION
## Summary
- allow customizing base path in `vite.config.js`
- document `VITE_BASE_PATH` in env example
- expand GitHub Pages docs with new env variable

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684d10b20e2083208c6f9f3b9894cab6