### PR TITLE
Add 404 handler and test

### DIFF
--- a/server.js
+++ b/server.js
@@ -495,6 +495,11 @@ app.get('/model/:filename', async (req, res) => {
   }
 });
 
+// Catch-all 404 handler
+app.use((req, res) => {
+  res.status(404).json({ error: 'Not Found' });
+});
+
 async function main() {
   try {
     await mongoose.connect(mongoUri);

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -271,6 +271,12 @@ describe('API endpoints', () => {
     expect(res.status).toBe(429);
     delete process.env.RATE_LIMIT_MAX;
   });
+
+  it('returns JSON 404 for unknown route', async () => {
+    const res = await request(app).get('/non-existent');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Not Found' });
+  });
 });
 
 describe('rate limit cleanup', () => {


### PR DESCRIPTION
## Summary
- add a catch‑all 404 middleware to return JSON response
- test that unknown routes return `{ error: 'Not Found' }`

## Testing
- `pnpm install` *(fails: unable to download pnpm)*
- `pnpm test` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_b_684d10be0aa88320a0d7ea8e3e409b1f