### PR TITLE
Add analytics tests

### DIFF
--- a/tests/analytics.test.js
+++ b/tests/analytics.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { logEvent } from '../src/utils/analytics.js';
+
+describe('logEvent', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends POST when endpoint defined', async () => {
+    import.meta.env.VITE_ANALYTICS_ENDPOINT = 'https://example.com/analytics';
+
+    await logEvent('testEvent', { a: 1 });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.com/analytics',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+  });
+
+  it('does nothing when endpoint empty', async () => {
+    import.meta.env.VITE_ANALYTICS_ENDPOINT = '';
+
+    await logEvent('testEvent');
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- test analytics logEvent function
- keep Vitest config to use Node environment

## Testing
- `pnpm lint` *(fails: unable to download pnpm)*
- `pnpm test` *(fails: unable to download pnpm)*

------
https://chatgpt.com/codex/tasks/task_b_684d10d79c608320b4fc15808f729a38