### PR TITLE
Fix tests for upload path and role middleware

### DIFF
--- a/tests/cp.test.js
+++ b/tests/cp.test.js
@@ -165,8 +165,9 @@ describe('cp page interactions', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     const [url, opts] = fetch.mock.calls[0];
-    expect(url).toBe('/upload');
-    expect(opts.headers).toEqual({ Authorization: 'Bearer null' });
+    const base = import.meta.env.VITE_API_BASE_URL || '';
+    expect(url).toBe(`${base}/upload`);
+    expect(opts.headers).toEqual({});
     expect(opts.method).toBe('POST');
     const body = opts.body;
     expect(body).toBeInstanceOf(FormData);

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -9,6 +9,7 @@ import mongoose from 'mongoose';
 import { sign } from './helpers/sign.js';
 import jwt from 'jsonwebtoken';
 import { S3Client } from '@aws-sdk/client-s3';
+import express from 'express';
 
 describe('API endpoints', () => {
   let originalR2;
@@ -214,11 +215,12 @@ describe('API endpoints', () => {
     vi.spyOn(User, 'findOne').mockResolvedValue(user);
     vi.spyOn(jwt, 'verify').mockReturnValue({ id: '1' });
     const token = 'token';
-    app.get('/test/me', requireRole('admin'), (req, res) => {
+    const testApp = express();
+    testApp.get('/test/me', requireRole('admin'), (req, res) => {
       res.json(req.user);
     });
 
-    const res = await request(app)
+    const res = await request(testApp)
       .get('/test/me')
       .set('Authorization', `Bearer ${token}`);
 
@@ -231,11 +233,12 @@ describe('API endpoints', () => {
     process.env.JWT_SECRET = 's';
     vi.spyOn(jwt, 'verify').mockReturnValue({ id: 1 });
     const token = 'bad';
-    app.get('/test/bad', requireRole('admin'), (req, res) => {
+    const testApp = express();
+    testApp.get('/test/bad', requireRole('admin'), (req, res) => {
       res.json({});
     });
 
-    const res = await request(app)
+    const res = await request(testApp)
       .get('/test/bad')
       .set('Authorization', `Bearer ${token}`);
 


### PR DESCRIPTION
## Summary
- update cp page test to use defined API_BASE and empty headers
- create isolated Express apps in server auth middleware tests

## Testing
- `pnpm test` *(fails: Error when performing the request to registry.npmjs.org)*
- `pnpm lint` *(fails: Error when performing the request to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_684d133044dc8320aa8487e92363d414