### PR TITLE
Fix cp test env handling

### DIFF
--- a/tests/cp.test.js
+++ b/tests/cp.test.js
@@ -22,10 +22,14 @@ vi.mock('../src/utils/models.js', () => modelsMocks);
 vi.mock('../src/utils/editForm.js', () => ({ showEditForm: vi.fn() }));
 
 let store;
+let oldBase;
 
 beforeEach(() => {
   vi.restoreAllMocks();
   vi.resetModules();
+
+  oldBase = process.env.VITE_API_BASE_URL;
+  process.env.VITE_API_BASE_URL = '';
 
   Object.values(authMocks).forEach((fn) => fn.mockReset());
   Object.values(modelsMocks).forEach((fn) => fn.mockReset());
@@ -67,6 +71,7 @@ beforeEach(() => {
 afterEach(() => {
   delete global.localStorage;
   vi.restoreAllMocks();
+  if (oldBase === undefined) delete process.env.VITE_API_BASE_URL; else process.env.VITE_API_BASE_URL = oldBase;
 });
 
 async function importCp() {
@@ -165,8 +170,9 @@ describe('cp page interactions', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     const [url, opts] = fetch.mock.calls[0];
-    expect(url).toBe('/upload');
-    expect(opts.headers).toEqual({ Authorization: 'Bearer null' });
+    const base = import.meta.env.VITE_API_BASE_URL || '';
+    expect(url).toBe(base + '/upload');
+    expect(opts.headers).toEqual({});
     expect(opts.method).toBe('POST');
     const body = opts.body;
     expect(body).toBeInstanceOf(FormData);


### PR DESCRIPTION
## Summary
- reset VITE_API_BASE_URL for each cp test to avoid side effects
- expect upload URL to include configured base and skip auth header

## Testing
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684d1413198c832092bf23264da16dd5