### PR TITLE
Fix cp upload test for base URL

### DIFF
--- a/tests/cp.test.js
+++ b/tests/cp.test.js
@@ -165,8 +165,9 @@ describe('cp page interactions', () => {
 
     expect(fetch).toHaveBeenCalledTimes(1);
     const [url, opts] = fetch.mock.calls[0];
-    expect(url).toBe('/upload');
-    expect(opts.headers).toEqual({ Authorization: 'Bearer null' });
+    const base = import.meta.env.VITE_API_BASE_URL || '';
+    expect(url).toBe(`${base}/upload`);
+    expect(opts.headers).toEqual({});
     expect(opts.method).toBe('POST');
     const body = opts.body;
     expect(body).toBeInstanceOf(FormData);


### PR DESCRIPTION
## Summary
- update `cp.test.js` upload test with dynamic base URL
- expect empty headers when no auth token is available

## Testing
- `pnpm test` *(fails: Request was cancelled due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_b_684d141c3fc48320addac8d3a40005f4