### PR TITLE
Fix tests for cp and server

### DIFF
--- a/server.js
+++ b/server.js
@@ -496,9 +496,12 @@ app.get('/model/:filename', async (req, res) => {
 });
 
 // Catch-all 404 handler
-app.use((req, res) => {
+export function notFound(req, res) {
   res.status(404).json({ error: 'Not Found' });
-});
+}
+app.use(notFound);
+// expose for tests
+global.notFound = notFound;
 
 async function main() {
   try {

--- a/src/cp.js
+++ b/src/cp.js
@@ -73,7 +73,7 @@ loginForm.addEventListener('submit', async (e) => {
     showRegister = false;
     updateAuthUI();
   } catch (err) {
-    showMessage(err.message, true);
+    window.showMessage(err.message, true);
   }
 });
 
@@ -89,7 +89,7 @@ registerForm.addEventListener('submit', async (e) => {
     showRegister = false;
     updateAuthUI();
   } catch (err) {
-    showMessage(err.message, true);
+    window.showMessage(err.message, true);
   }
 });
 
@@ -126,11 +126,11 @@ async function handleUpload(e) {
     });
     const data = await res.json().catch(() => ({}));
     if (!res.ok) throw new Error(data.error || `Upload failed: ${res.status}`);
-    showMessage('Uploaded');
+    window.showMessage('Uploaded');
     uploadForm.reset();
     await refreshModels();
   } catch (err) {
-    showMessage(err.message, true);
+    window.showMessage(err.message, true);
   }
 }
 
@@ -160,10 +160,10 @@ function renderModels(list) {
         if (!confirm('Delete this model?')) return;
         try {
           await deleteModel(li.dataset.id);
-          showMessage('Model deleted');
+          window.showMessage('Model deleted');
           await refreshModels();
         } catch (err) {
-          showMessage(err.message, true);
+          window.showMessage(err.message, true);
         }
       });
       li.appendChild(delBtn);
@@ -179,7 +179,7 @@ export async function refreshModels() {
     renderModels(list);
   } catch (err) {
     modelsList.innerHTML = '';
-    showMessage(err.message || 'Failed to load models', true);
+    window.showMessage(err.message || 'Failed to load models', true);
   }
 }
 

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -9,7 +9,6 @@ import mongoose from 'mongoose';
 import { sign } from './helpers/sign.js';
 import jwt from 'jsonwebtoken';
 import { S3Client } from '@aws-sdk/client-s3';
-import express from 'express';
 
 describe('API endpoints', () => {
   let originalR2;


### PR DESCRIPTION
## Summary
- call global `showMessage` from cp module so it can be spied
- expose 404 handler from server.js for tests
- remove unused import from `server.test.js`

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_684d16d267c08320a5d22686f68e2444