### PR TITLE
Define notFound handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -500,8 +500,6 @@ export function notFound(req, res) {
   res.status(404).json({ error: 'Not Found' });
 }
 app.use(notFound);
-// expose for tests
-global.notFound = notFound;
 
 async function main() {
   try {

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -2,7 +2,7 @@ process.env.NODE_ENV = 'test';
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
-import { app, Model, main, User, requireRole } from '../server.js';
+import { app, Model, main, User, requireRole, notFound } from '../server.js';
 import fs from 'fs';
 import path from 'path';
 import mongoose from 'mongoose';
@@ -221,6 +221,7 @@ describe('API endpoints', () => {
 
       res.json(req.user);
     });
+    app._router.stack.push(notFound);
 
     const res = await request(testApp)
       .get('/test/me')
@@ -242,6 +243,7 @@ describe('API endpoints', () => {
 
       res.json({});
     });
+    app._router.stack.push(notFound);
 
     const res = await request(testApp)
       .get('/test/bad')


### PR DESCRIPTION
## Summary
- add exported `notFound` handler
- use the handler in API tests

## Testing
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684d18b7398883208674cf813c97d266