### PR TITLE
Update tests to use notFound middleware

### DIFF
--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -221,7 +221,7 @@ describe('API endpoints', () => {
 
       res.json(req.user);
     });
-    app._router.stack.push(notFound);
+    testApp.use(notFound);
 
     const res = await request(testApp)
       .get('/test/me')
@@ -243,7 +243,7 @@ describe('API endpoints', () => {
 
       res.json({});
     });
-    app._router.stack.push(notFound);
+    testApp.use(notFound);
 
     const res = await request(testApp)
       .get('/test/bad')


### PR DESCRIPTION
## Summary
- add notFound middleware in isolated Express apps in server tests

## Testing
- `pnpm install` *(fails: Request was cancelled)*
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684d19adab308320a97c12b26f440e00