### PR TITLE
Fix spy in uploads model test

### DIFF
--- a/tests/cp.test.js
+++ b/tests/cp.test.js
@@ -163,7 +163,7 @@ describe('cp page interactions', () => {
 
     const cp = await importCp();
     const refreshSpy = vi.spyOn(cp, 'refreshModels');
-    const showSpy = vi.spyOn(cp, 'showMessage');
+    const showSpy = vi.spyOn(window, 'showMessage');
     const form = document.getElementById('upload-form');
     const fileInput = document.getElementById('upload-file');
     const file = new File(['x'], 'm.glb');


### PR DESCRIPTION
## Summary
- correct spy target in cp tests

## Testing
- `pnpm test` *(fails: Error when performing the request to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_684d1de11b1c8320a8fa1c971d1a23a0