### PR TITLE
Update upload model test

### DIFF
--- a/tests/cp.test.js
+++ b/tests/cp.test.js
@@ -163,7 +163,6 @@ describe('cp page interactions', () => {
 
     const cp = await importCp();
     const refreshSpy = vi.spyOn(cp, 'refreshModels');
-    const showSpy = vi.spyOn(window, 'showMessage');
     const form = document.getElementById('upload-form');
     const fileInput = document.getElementById('upload-file');
     const file = new File(['x'], 'm.glb');
@@ -188,7 +187,7 @@ describe('cp page interactions', () => {
     expect(body.get('model')).toEqual(file);
     expect(body.get('markerIndex')).toBe('0');
     expect(resetSpy).toHaveBeenCalled();
-    expect(showSpy).toHaveBeenCalledWith('Uploaded');
+    expect(document.getElementById('message').textContent).toBe('Uploaded');
     expect(refreshSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- remove unused spy on `showMessage`
- check the DOM message content instead in the upload test

## Testing
- `pnpm test` *(fails: request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_b_684d1f6e13ec8320bbd7530fad5c0253