### PR TITLE
Fix refreshModels spy

### DIFF
--- a/tests/cp.test.js
+++ b/tests/cp.test.js
@@ -162,7 +162,7 @@ describe('cp page interactions', () => {
     fetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({}) });
 
     const cp = await importCp();
-    const refreshSpy = vi.spyOn(cp, 'refreshModels');
+    const refreshSpy = vi.spyOn(window, 'refreshModels');
     const form = document.getElementById('upload-form');
     const fileInput = document.getElementById('upload-file');
     const file = new File(['x'], 'm.glb');


### PR DESCRIPTION
## Summary
- update cp page test to spy on the global `refreshModels`

## Testing
- `pnpm test` *(fails: cannot download pnpm)*

------
https://chatgpt.com/codex/tasks/task_b_684d232f0b488320a3e035c21c12f761