### PR TITLE
Fix unused variable in tests

### DIFF
--- a/tests/cp.test.js
+++ b/tests/cp.test.js
@@ -161,7 +161,7 @@ describe('cp page interactions', () => {
     authMocks.getRole.mockReturnValue('admin');
     fetch.mockResolvedValue({ ok: true, json: vi.fn().mockResolvedValue({}) });
 
-    const cp = await importCp();
+    await importCp();
     const refreshSpy = vi.spyOn(window, 'refreshModels');
     const form = document.getElementById('upload-form');
     const fileInput = document.getElementById('upload-file');


### PR DESCRIPTION
## Summary
- remove unused variable `cp` in `tests/cp.test.js`

## Testing
- `pnpm lint` *(fails: request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_b_684d241857348320b8afc2a1c7f270ea