### PR TITLE
Fix refreshModels spy

### DIFF
--- a/src/cp.js
+++ b/src/cp.js
@@ -128,7 +128,7 @@ async function handleUpload(e) {
     if (!res.ok) throw new Error(data.error || `Upload failed: ${res.status}`);
     showMessage('Uploaded');
     uploadForm.reset();
-    await refreshModels();
+    await window.refreshModels();
   } catch (err) {
     showMessage(err.message, true);
   }
@@ -161,7 +161,7 @@ function renderModels(list) {
         try {
           await deleteModel(li.dataset.id);
           showMessage('Model deleted');
-          await refreshModels();
+          await window.refreshModels();
         } catch (err) {
           showMessage(err.message, true);
         }
@@ -186,4 +186,4 @@ export async function refreshModels() {
 window.refreshModels = refreshModels;
 
 updateAuthUI();
-refreshModels();
+window.refreshModels();


### PR DESCRIPTION
## Summary
- call `refreshModels` via `window` so it can be spied in tests

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*
- `NODE_ENV=test pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.12.1.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_684d24c2698c8320876825dab49f2cfe