### PR TITLE
Add Render ping workflow

### DIFF
--- a/.github/workflows/ping-render.yml
+++ b/.github/workflows/ping-render.yml
@@ -1,0 +1,11 @@
+# Pings Render.com API to keep the service awake
+name: Render keep awake
+on:
+  schedule:
+    - cron: '*/14 * * * *'
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping API
+        run: curl -fsS https://web-app-ar-api.onrender.com/api/models

--- a/README.en.md
+++ b/README.en.md
@@ -89,6 +89,10 @@ Use `pnpm build` for a production build and `pnpm preview` to preview the output
 4. Optionally configure GitHub Actions for automatic deployment.
 5. Ensure paths in `index.html` are correct. GitHub Pages serves content over HTTPS which is required for AR.
 
+## Keeping Render Awake
+
+The repository includes `.github/workflows/ping-render.yml` which pings the Render API periodically so the service does not go to sleep.
+
 ## License
 
 [MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ pnpm start  # запуск API-сервера (опционально)
 
 #### GitHub Actions
 
-Создай файл `.github/workflows/ping-render.yml` со следующим содержимым:
+В репозитории уже имеется файл `.github/workflows/ping-render.yml` со следующим содержимым:
 
 ```yaml
 name: Render keep awake


### PR DESCRIPTION
## Summary
- add `.github/workflows/ping-render.yml` for pinging the Render API
- note the workflow in the Russian and English READMEs

## Testing
- `pnpm install` *(fails: Request was cancelled)*
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm test` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_b_684d46fb8e9c832095633349bc4d5aee