### PR TITLE
docs: clarify windows build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ pnpm start  # запуск API-сервера (опционально)
    VITE_API_BASE_URL=https://example.com pnpm build
    ```
 
+   Для Windows:
+   - `cmd.exe`:
+     ```cmd
+     set VITE_API_BASE_URL=https://example.com && pnpm build
+     ```
+   - PowerShell:
+     ```powershell
+     $env:VITE_API_BASE_URL='https://example.com'; pnpm build
+     ```
+
    Не добавляй суффикс `/api` в конце URL
 
 3. Создай пустой файл `.nojekyll` в корне проекта, чтобы отключить обработку Jekyll на GitHub Pages.


### PR DESCRIPTION
## Summary
- note how to set VITE_API_BASE_URL when building on Windows

## Testing
- `pnpm install`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_684d6fb7554c832087264a6ee08586e9