### PR TITLE
Ignore majestic vendor bundle for lint/format

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+cms/majestic/vendor.bundle.base.js

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import globals from 'globals';
 
 export default [
   {
-    ignores: ['node_modules/**'],
+    ignores: ['node_modules/**', 'cms/majestic/vendor.bundle.base.js'],
   },
   js.configs.recommended,
   // Общие правила для JS-файлов фронта (браузер)


### PR DESCRIPTION
## Summary
- ignore `cms/majestic/vendor.bundle.base.js` in ESLint config
- exclude the vendor bundle from Prettier formatting

## Testing
- `pnpm install`
- `pnpm lint` *(fails: 4 errors in cms/majestic/template.js)*
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_b_684d8bfa384483208b5c712b75c26eab