### PR TITLE
Remove cms binaries and use remote assets

### DIFF
--- a/cms/majestic/style.css
+++ b/cms/majestic/style.css
@@ -4,6 +4,7 @@
   Project:	Majestic Admin
   Version:	1.1.0
 -------------------------------------------------------------------*/
+@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700;900&display=swap");
 /*-------------------------------------------------------------------
   ===== Table of Contents =====
 
@@ -19965,65 +19966,6 @@ input:focus {
   outline: none;
 }
 
-@font-face {
-  font-family: 'Roboto';
-  src: url('../fonts/Roboto/Roboto-Light.eot');
-  src:
-    url('../fonts/Roboto/Roboto-Light.eot?#iefix') format('embedded-opentype'),
-    url('../fonts/Roboto/Roboto-Light.woff2') format('woff2'),
-    url('../fonts/Roboto/Roboto-Light.woff') format('woff'),
-    url('../fonts/Roboto/Roboto-Light.ttf') format('truetype');
-  font-weight: 300;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('../fonts/Roboto/Roboto-Bold.eot');
-  src:
-    url('../fonts/Roboto/Roboto-Bold.eot?#iefix') format('embedded-opentype'),
-    url('../fonts/Roboto/Roboto-Bold.woff2') format('woff2'),
-    url('../fonts/Roboto/Roboto-Bold.woff') format('woff'),
-    url('../fonts/Roboto/Roboto-Bold.ttf') format('truetype');
-  font-weight: bold;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('../fonts/Roboto/Roboto-Medium.eot');
-  src:
-    url('../fonts/Roboto/Roboto-Medium.eot?#iefix') format('embedded-opentype'),
-    url('../fonts/Roboto/Roboto-Medium.woff2') format('woff2'),
-    url('../fonts/Roboto/Roboto-Medium.woff') format('woff'),
-    url('../fonts/Roboto/Roboto-Medium.ttf') format('truetype');
-  font-weight: 500;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('../fonts/Roboto/Roboto-Regular.eot');
-  src:
-    url('../fonts/Roboto/Roboto-Regular.eot?#iefix') format('embedded-opentype'),
-    url('../fonts/Roboto/Roboto-Regular.woff2') format('woff2'),
-    url('../fonts/Roboto/Roboto-Regular.woff') format('woff'),
-    url('../fonts/Roboto/Roboto-Regular.ttf') format('truetype');
-  font-weight: normal;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: 'Roboto';
-  src: url('../fonts/Roboto/Roboto-Black.eot');
-  src:
-    url('../fonts/Roboto/Roboto-Black.eot?#iefix') format('embedded-opentype'),
-    url('../fonts/Roboto/Roboto-Black.woff2') format('woff2'),
-    url('../fonts/Roboto/Roboto-Black.woff') format('woff'),
-    url('../fonts/Roboto/Roboto-Black.ttf') format('truetype');
-  font-weight: 900;
-  font-style: normal;
-}
 
 .bg-twitter {
   background: #2caae1;
@@ -23048,17 +22990,17 @@ dl li {
 /* === Landing screens === */
 /* Auth */
 .auth .login-half-bg {
-  background: url('../images/auth/login-bg.jpg');
+  background: url('https://via.placeholder.com/800x600?text=Login+BG');
   background-size: cover;
 }
 
 .auth .register-half-bg {
-  background: url('../images/auth/register-bg.jpg');
+  background: url('https://via.placeholder.com/800x600?text=Register+BG');
   background-size: cover;
 }
 
 .auth.lock-full-bg {
-  background: url('../images/auth/lockscreen-bg.jpg');
+  background: url('https://via.placeholder.com/800x600?text=Lockscreen+BG');
   background-size: cover;
 }
 


### PR DESCRIPTION
## Summary
- clean up Majestic CSS to import Roboto from Google Fonts
- switch CMS background images to placeholders

## Testing
- `pnpm lint` *(fails: template.js unused vars)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_684d8e46ec88832095dcca0466942770