### PR TITLE
Fix jQuery lint error

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,7 @@ export default [
         document: 'readonly',
         console: 'readonly',
         alert: 'readonly',
+        jQuery: 'readonly',
       },
     },
     plugins: {


### PR DESCRIPTION
## Summary
- add `jQuery` to the globals list so ESLint recognizes the jQuery global

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_684d9708938883208b62f8030e329527