### PR TITLE
Add CI lint log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ package-lock.json
 
 # Ignore leftover patch files
 change.patch
+lint.log

--- a/README.en.md
+++ b/README.en.md
@@ -55,6 +55,7 @@ Copy `.env.example` to `.env` and adjust values as needed. Important variables:
 
 - `pnpm dev` – run the Vite dev server
 - `pnpm lint` – run ESLint
+  In CI the output is written to `lint.log`; view this file if the check fails.
 - `pnpm test` – run Vitest
 - _Make sure `pnpm install` has been run before these commands._
 - `pnpm format` – run Prettier

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ MODEL_URL=<url> sh public/assets/download_models.sh
 # MODEL_URL=https://<account>.r2.cloudflarestorage.com/<bucket>/model.glb sh public/assets/download_models.sh
 pnpm dev
 pnpm lint # проверка стиля (требует предварительного pnpm install)
+# В CI вывод сохраняется в lint.log — открой файл, если проверка завершилась с ошибкой
 pnpm test  # запуск тестов
 # Vitest по умолчанию запускается в среде Node.
 # jsdom подключается только для DOM-тестов через директиву
@@ -330,6 +331,7 @@ RATE_LIMIT_MAX=
 
 ```bash
 pnpm lint
+# В CI журнал сохраняется в lint.log
 pnpm format
 ```
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint .",
+    "lint": "node scripts/run-lint.js",
     "prelint": "node scripts/check-deps.js",
     "test": "vitest run",
     "pretest": "node scripts/check-deps.js",

--- a/scripts/run-lint.js
+++ b/scripts/run-lint.js
@@ -1,0 +1,22 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+
+const useLog = !!process.env.CI;
+const eslintArgs = ['exec', 'eslint', '.', ...process.argv.slice(2)];
+const child = spawn('pnpm', eslintArgs, {
+  stdio: useLog ? ['inherit', 'pipe', 'pipe'] : 'inherit',
+  shell: true,
+});
+
+if (useLog) {
+  const log = fs.createWriteStream('lint.log', { flags: 'w' });
+  child.stdout.pipe(process.stdout);
+  child.stderr.pipe(process.stderr);
+  child.stdout.pipe(log);
+  child.stderr.pipe(log);
+  child.on('close', (code) => {
+    log.end(() => process.exit(code));
+  });
+} else {
+  child.on('close', (code) => process.exit(code));
+}


### PR DESCRIPTION
## Summary
- log ESLint output to `lint.log` when running in CI
- document the log file in both READMEs
- ignore `lint.log`

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_684d9700bd108320af592c7066218923