### PR TITLE
docs: clarify CMS usage

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -67,6 +67,8 @@ Copy `.env.example` to `.env` and adjust values as needed. Important variables:
 
 Open [http://localhost:5173/web-app-ar/](http://localhost:5173/web-app-ar/) and click **Start AR**. The camera page now shows only the AR view with a **CMS** link for switching to the content manager, and the CMS page has a **Back to Camera** link.
 
+The CMS under `cms/` is based on **MajesticAdmin**. Open it via `${base}cms/`, where `${base}` is the `base` value in `vite.config.js` (default `/web-app-ar/`). For local development this means `http://localhost:5173/web-app-ar/cms/`. Register a user with `role: admin` through `/auth/register` to enable the **Upload** form and manage models.
+
 The Majestic template fonts and background images are loaded from external CDNs
 (Google Fonts and placeholder.com) to keep the repository slim (the original
 files were about 3.8 MB). If you prefer local assets, place them in

--- a/README.md
+++ b/README.md
@@ -53,10 +53,20 @@ project-root/
 
 ## CMS
 
-1. Запустите `pnpm dev`.
-2. Откройте `http://localhost:5173/web-app-ar/cms/`.
-3. Задайте `VITE_API_BASE_URL` в `.env` и авторизуйтесь для загрузки моделей.
-4. При необходимости скачайте исходный шаблон **Majestic Admin** с GitHub:
+Каталог `cms/` основан на шаблоне **MajesticAdmin**. Страницу CMS следует
+открывать по пути `${base}cms/`, где `${base}` — значение `base` из
+`vite.config.js` (по умолчанию `/web-app-ar/`). Пример локального URL:
+`http://localhost:5173/web-app-ar/cms/`.
+
+1. Запустите `pnpm dev` и API командой `pnpm api`.
+2. Укажите `VITE_API_BASE_URL` в `.env`.
+3. Зарегистрируйте пользователя с ролью `admin` через `/auth/register` и
+   войдите в CMS. После входа станет доступна форма **Upload** для загрузки
+   моделей.
+4. Для использования локальных шрифтов и изображений поместите файлы в
+   `cms/fonts/` и `cms/images/`, скорректировав пути в
+   `public/cms/majestic/style.css`.
+5. При необходимости скачайте исходный шаблон Majestic Admin с GitHub:
    <https://github.com/BootstrapDash/MajesticAdmin-Free-Bootstrap-Admin-Template/archive/refs/heads/master.zip>
    и распакуйте файлы в каталог `cms/`.
 


### PR DESCRIPTION
## Summary
- document Majestic Admin CMS path and base URL
- explain how to enable uploads via admin auth
- mention using local fonts and images

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_684dd92554088320ad224afe03f9e4f5