### PR TITLE
Fix lint issues by ignoring CMS

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ export default [
       'public/cms/majestic/**',
       'public/cms/majestic/vendor.bundle.base.js',
       'public/cms/majestic/template.js',
+      'cms/**',
       'dist/**',
     ],
   },


### PR DESCRIPTION
## Summary
- exclude `cms/` from ESLint checks

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `curl -I http://localhost:5174/web-app-ar/cms/`

------
https://chatgpt.com/codex/tasks/task_b_684e920faad08320b269e180b69f5a07