### PR TITLE
Add model preview via query parameter

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,9 +96,22 @@
       cmsLink.href = `${base}cms/`;
 
       let list = [];
-      try {
-        list = await loadModels();
-      } catch {}
+      const params = new URLSearchParams(window.location.search);
+      const id = params.get('id');
+      if (id) {
+        try {
+          const API_BASE =
+            (import.meta.env.VITE_API_BASE_URL || '').trim() ||
+            window.location.origin;
+          const res = await fetch(`${API_BASE}/api/models/${id}`);
+          if (res.ok) list = [await res.json()];
+        } catch {}
+      }
+      if (list.length === 0) {
+        try {
+          list = await loadModels();
+        } catch {}
+      }
 
       startButton.addEventListener('click', async () => {
         const started = await startAR(list);

--- a/src/catalog.js
+++ b/src/catalog.js
@@ -1,4 +1,3 @@
-
 async function loadCatalog() {
   const res = await fetch('../api/models');
   const list = await res.json();
@@ -23,7 +22,7 @@ $('#search').on('input', loadCatalog);
 
 $('#catalog-container').on('click', '.preview', function () {
   const id = $(this).data('id');
-  window.open(`../api/models/${id}`, '_blank');
+  window.open(`../index.html?id=${id}`, '_blank');
 });
 
 loadCatalog();


### PR DESCRIPTION
## Summary
- support `id` query parameter in `index.html` for loading a single model
- update catalog preview buttons to open AR page with the selected model

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm preview` (manually stopped)

------
https://chatgpt.com/codex/tasks/task_b_684e9aedbfec832090e776149d992761