### PR TITLE
Fix catalog API base

### DIFF
--- a/src/catalog.js
+++ b/src/catalog.js
@@ -1,6 +1,7 @@
+import { loadModels as fetchModels } from './utils/models.js';
+
 async function loadCatalog() {
-  const res = await fetch('../api/models');
-  const list = await res.json();
+  const list = await fetchModels();
   render(list);
 }
 


### PR DESCRIPTION
## Summary
- use helper to load models in `catalog.js`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_684ea2b4ceac832082db5263379fa678