### PR TITLE
Add API connectivity check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "format": "prettier --write \"**/*.{js,css,html,json,md}\"",
     "format:check": "prettier --check \"**/*.{js,css,html,json,md}\"",
     "api": "node server.js",
-    "start": "node server.js"
+    "start": "node server.js",
+    "check-api": "node scripts/check-api.js"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.548.0",

--- a/scripts/check-api.js
+++ b/scripts/check-api.js
@@ -1,0 +1,15 @@
+const base =
+  (process.env.VITE_API_BASE_URL || '').trim() || 'http://localhost:3000';
+const url = base.replace(/\/$/, '') + '/api/models';
+fetch(url)
+  .then((res) => {
+    if (!res.ok) throw new Error(`Status ${res.status}`);
+    return res.json();
+  })
+  .then(() => {
+    console.log(`✅ [api] reachable at ${base}`);
+  })
+  .catch((err) => {
+    console.error(`❌ [api] request failed: ${err.message}`);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add `scripts/check-api.js` to validate connectivity to the backend
- expose `pnpm run check-api` script in `package.json`

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- `pnpm run check-api` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_684ea4934300832086efabbe484fad10