### PR TITLE
Fix missing CMS pages in build

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -79,6 +79,9 @@ repository history.
 If you need the original template, download it from GitHub:
 <https://github.com/BootstrapDash/MajesticAdmin-Free-Bootstrap-Admin-Template/archive/refs/heads/master.zip>.
 
+When deploying to GitHub Pages, include the pages under `cms/app/` in
+`rollupOptions.input` inside `vite.config.js` so they are copied to `dist/`.
+
 ## Build
 
 Use `pnpm build` for a production build and `pnpm preview` to preview the output.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ project-root/
 5. При необходимости скачайте исходный шаблон Majestic Admin с GitHub:
    <https://github.com/BootstrapDash/MajesticAdmin-Free-Bootstrap-Admin-Template/archive/refs/heads/master.zip>
    и распакуйте файлы в каталог `cms/`.
+6. Для публикации на GitHub Pages добавьте страницы из `cms/app/` в
+   `rollupOptions.input` в `vite.config.js`.
 
 ## Сборка и деплой
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,10 @@ export default defineConfig(({ mode }) => {
         input: {
           main: 'index.html',
           cms: 'cms/index.html',
+          catalog: 'cms/app/catalog.html',
+          login: 'cms/app/login.html',
+          profile: 'cms/app/profile.html',
+          register: 'cms/app/register.html',
         },
       },
     },


### PR DESCRIPTION
## Summary
- add CMS app pages to rollup build inputs
- document the need to include `cms/app/` pages for GitHub Pages

## Testing
- `pnpm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_b_684eaaaf9c4883208a69df3617ef75c8