### PR TITLE
Fix CMS asset references

### DIFF
--- a/cms/app/catalog.html
+++ b/cms/app/catalog.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <title>Catalog</title>
-  <link rel="stylesheet" href="../majestic/vendor.bundle.base.css" />
-  <link rel="stylesheet" href="../majestic/style.css" />
+  <link rel="stylesheet" href="/cms/majestic/vendor.bundle.base.css" />
+  <link rel="stylesheet" href="/cms/majestic/style.css" />
 </head>
 <body>
   <div class="container-scroller">
@@ -48,8 +48,8 @@
       </div>
     </div>
   </div>
-  <script src="../majestic/vendor.bundle.base.js"></script>
-  <script src="../majestic/template.js"></script>
+  <script src="/cms/majestic/vendor.bundle.base.js"></script>
+  <script src="/cms/majestic/template.js"></script>
   <script type="module" src="../../src/catalog.js"></script>
 </body>
 </html>

--- a/cms/app/login.html
+++ b/cms/app/login.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <title>Login</title>
-  <link rel="stylesheet" href="../majestic/vendor.bundle.base.css" />
-  <link rel="stylesheet" href="../majestic/style.css" />
+  <link rel="stylesheet" href="/cms/majestic/vendor.bundle.base.css" />
+  <link rel="stylesheet" href="/cms/majestic/style.css" />
 </head>
 <body>
   <div class="container-scroller">
@@ -42,8 +42,8 @@
       </div>
     </div>
   </div>
-  <script src="../majestic/vendor.bundle.base.js"></script>
-  <script src="../majestic/template.js"></script>
+  <script src="/cms/majestic/vendor.bundle.base.js"></script>
+  <script src="/cms/majestic/template.js"></script>
   <script type="module" src="../../src/login.js"></script>
 </body>
 </html>

--- a/cms/app/profile.html
+++ b/cms/app/profile.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <title>Profile</title>
-  <link rel="stylesheet" href="../majestic/vendor.bundle.base.css" />
-  <link rel="stylesheet" href="../majestic/style.css" />
+  <link rel="stylesheet" href="/cms/majestic/vendor.bundle.base.css" />
+  <link rel="stylesheet" href="/cms/majestic/style.css" />
 </head>
 <body>
   <div class="container-scroller">
@@ -64,8 +64,8 @@
       </div>
     </div>
   </div>
-  <script src="../majestic/vendor.bundle.base.js"></script>
-  <script src="../majestic/template.js"></script>
+  <script src="/cms/majestic/vendor.bundle.base.js"></script>
+  <script src="/cms/majestic/template.js"></script>
   <script type="module" src="../../src/profile.js"></script>
 </body>
 </html>

--- a/cms/app/register.html
+++ b/cms/app/register.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
   <title>Register</title>
-  <link rel="stylesheet" href="../majestic/vendor.bundle.base.css" />
-  <link rel="stylesheet" href="../majestic/style.css" />
+  <link rel="stylesheet" href="/cms/majestic/vendor.bundle.base.css" />
+  <link rel="stylesheet" href="/cms/majestic/style.css" />
 </head>
 <body>
   <div class="container-scroller">
@@ -45,8 +45,8 @@
       </div>
     </div>
   </div>
-  <script src="../majestic/vendor.bundle.base.js"></script>
-  <script src="../majestic/template.js"></script>
+  <script src="/cms/majestic/vendor.bundle.base.js"></script>
+  <script src="/cms/majestic/template.js"></script>
   <script type="module" src="../../src/register.js"></script>
 </body>
 </html>

--- a/cms/index-old.html
+++ b/cms/index-old.html
@@ -7,8 +7,8 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <title>CMS</title>
-    <link rel="stylesheet" href="../cms/majestic/vendor.bundle.base.css" />
-    <link rel="stylesheet" href="../cms/majestic/style.css" />
+    <link rel="stylesheet" href="/cms/majestic/vendor.bundle.base.css" />
+    <link rel="stylesheet" href="/cms/majestic/style.css" />
   </head>
   <body>
     <div class="container-scroller">
@@ -143,8 +143,8 @@
         </div>
       </div>
     </div>
-    <script src="../cms/majestic/vendor.bundle.base.js"></script>
-    <script src="../cms/majestic/template.js"></script>
+    <script src="/cms/majestic/vendor.bundle.base.js"></script>
+    <script src="/cms/majestic/template.js"></script>
     <script type="module" src="../src/cp.js"></script>
   </body>
 </html>

--- a/cms/index.html
+++ b/cms/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
     <title>CMS</title>
-    <link rel="stylesheet" href="./majestic/vendor.bundle.base.css" />
-    <link rel="stylesheet" href="./majestic/style.css" />
+    <link rel="stylesheet" href="/cms/majestic/vendor.bundle.base.css" />
+    <link rel="stylesheet" href="/cms/majestic/style.css" />
   </head>
   <body>
     <div class="container-scroller">
@@ -75,8 +75,8 @@
         </div>
       </div>
     </div>
-    <script src="./majestic/vendor.bundle.base.js"></script>
-    <script src="./majestic/template.js"></script>
+    <script src="/cms/majestic/vendor.bundle.base.js"></script>
+    <script src="/cms/majestic/template.js"></script>
     <script type="module" src="../src/cp.js"></script>
     <script type="module">
       const base = import.meta.env.BASE_URL;


### PR DESCRIPTION
## Summary
- point CMS pages at static `/cms/majestic` files again
- drop binary font and image assets from repo

## Testing
- `pnpm install`
- `pnpm format`
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_684eafc446e8832085e6617e750a0a45