### PR TITLE
Implement dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,12 +74,13 @@
     </style>
   </head>
 
-  <body>
+  <body class="bg-white dark:bg-black text-black dark:text-white">
     <div id="ar-container"></div>
     <div id="ar-frame"></div>
     <div id="ar-overlay">
       <button id="start-ar">Start AR</button>
       <a id="cms-link" href="#">CMS</a>
+      <button id="toggle-theme" aria-label="toggle theme">🌓</button>
     </div>
     <div id="instructions">
       После распознавания маркера появятся ползунки для поворота и
@@ -92,8 +93,10 @@
       const instructions = document.getElementById('instructions');
       const { startAR } = await import('./src/ar-scene.js');
       const { loadModels } = await import('./src/utils/models.js');
+      const { initThemeToggle } = await import('./src/utils/theme.js');
       const base = import.meta.env.BASE_URL;
       cmsLink.href = `${base}cms/`;
+      initThemeToggle('toggle-theme');
 
       let list = [];
       const params = new URLSearchParams(window.location.search);

--- a/src/utils/theme.js
+++ b/src/utils/theme.js
@@ -1,0 +1,13 @@
+export function initThemeToggle(buttonId = 'toggle-theme') {
+  const root = document.documentElement;
+  const saved = localStorage.getItem('theme');
+  if (saved === 'dark') root.classList.add('dark');
+
+  const btn = document.getElementById(buttonId);
+  if (!btn) return;
+
+  btn.addEventListener('click', () => {
+    const dark = root.classList.toggle('dark');
+    localStorage.setItem('theme', dark ? 'dark' : 'light');
+  });
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 export default {
+  darkMode: 'class',
   content: ['./index.html', './cms/index.html', './src/**/*.{js,html}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- add client-side dark mode toggle
- enable `darkMode` in Tailwind config

## Testing
- `pnpm install`
- `pnpm format`
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_684ebec121d88320961ced172bb6ac67