### PR TITLE
Fix env header typo

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-# Eenvironment configuration
+# Environment configuration
 MONGODB_URI=mongodb+srv://codex:E42yK0YQDhdT670b@arjs-db.4pzoyda.mongodb.net/?retryWrites=true&w=majority&appName=arjs-db
 # JWT secret
 JWT_SECRET=Q7zTfSXY7RyHf7oPfqnbB0Qu3GSKZqKztTQ2fNSvCOI=


### PR DESCRIPTION
## Summary
- fix typo in `.env`

## Testing
- `pnpm install`
- `pnpm format`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68518610bd1c8320bf52dd510b743cb0