### PR TITLE
Fix worker config for Wrangler v4

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
 name = "web-app-ar-worker"
 main = "src/worker.ts"
-node_compat = true
-compatibility_date = "2024-05-01"
+compatibility_date = "2025-06-17"
+compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
## Summary
- update wrangler.toml: remove deprecated `node_compat`
- enable `nodejs_compat` and update compatibility date

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run worker:deploy` *(fails: missing Cloudflare API token)*

------
https://chatgpt.com/codex/tasks/task_b_6851938c289c8320a6a84296748f04a5