### PR TITLE
Fix cms deploy path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -23,7 +23,6 @@ export default defineConfig(({ mode }) => {
             dest: 'cms',
           },
         ],
-        structured: true,
       }),
     ],
     define: {


### PR DESCRIPTION
## Summary
- avoid nested `cms/cms` folder in production by removing the `structured` option from the static copy plugin

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_6851bb7753048320b1046e9e5da28870