### PR TITLE
Improve Pages action resiliency

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,3 +45,6 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+        with:
+          timeout: '900000'
+          error_count: '20'


### PR DESCRIPTION
## Summary
- increase timeout and error_count for Pages deploy

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm format`
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_6851c6a789ac832098a810f4747e2dd3