### PR TITLE
Fix Cloudflare Worker fetch handler

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -12,4 +12,9 @@ router.get('/api/models', async () => {
 
 router.all('*', () => new Response('Not Found', { status: 404 }))
 
-export default { fetch: router.handle }
+// Обработчик Cloudflare Worker
+export default {
+  async fetch(request: Request, env: unknown, ctx: ExecutionContext) {
+    return router.handle(request, env, ctx)
+  },
+}


### PR DESCRIPTION
## Summary
- ensure worker fetch handler is async so Cloudflare requires a `Promise<Response>`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_6851ce1e42608320949ca74a2679e959