### PR TITLE
Remove unused CMS path from tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,6 @@
 export default {
   darkMode: 'class',
-  content: ['./index.html', './cms/index.html', './ar-app/src/**/*.{js,html}'],
+  content: ['./index.html', './ar-app/src/**/*.{js,html}'],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- cleanup: drop `./cms/index.html` from Tailwind content array

## Testing
- `pnpm install` *(fails: Node.js v22 not supported)*
- `pnpm format`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_6851d255334c8320971a0ef3d75376b9